### PR TITLE
Don't ask to refresh for new items

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "Changeloglib"]
 	path = Changeloglib
 	url = https://github.com/David-Development/changeloglib.git
-[submodule "MessageBar"]
-	path = MessageBar
-	url = https://github.com/David-Development/MessageBar.git
 [submodule "ownCloud-Account-Importer"]
 	path = ownCloud-Account-Importer
 	url = https://github.com/David-Development/ownCloud-Account-Importer.git

--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -102,7 +102,6 @@ dependencies {
     compile files('src/main/libs/gson-2.2.4.jar')
     compile files('src/main/libs/jsoup-1.7.2.jar')
     compile project(':Changeloglib:ChangeLogLibrary')
-    compile project(':MessageBar')
     compile project(':ownCloud-Account-Importer')
     compile project(':ShowcaseView:library')
     compile project(':android-HoloCircularProgressBar:library')

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -51,10 +51,6 @@ import android.widget.ExpandableListView.OnChildClickListener;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import com.michaelflisar.messagebar.MessageBar;
-import com.michaelflisar.messagebar.messages.BaseMessage;
-import com.michaelflisar.messagebar.messages.TextMessage;
-
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.conn.HttpHostConnectException;
 
@@ -142,10 +138,12 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
                         SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
                         int newItemsCount = mPrefs.getInt(Constants.LAST_UPDATE_NEW_ITEMS_COUNT_STRING, 0);
                         if(newItemsCount > 0) {
-                            MessageBar messageBar = new MessageBar(getActivity(), true);
-                            TextMessage textMessage = new TextMessage(newItemsCount + " " + getString(R.string.message_bar_new_articles_available), getString(R.string.message_bar_reload), R.drawable.ic_menu_refresh);
-                            textMessage.setClickListener(mListener);
-                            messageBar.show(textMessage);
+							NewsReaderDetailFragment ndf = ((NewsReaderDetailFragment) getActivity().getSupportFragmentManager().findFragmentById(R.id.content_frame));
+							if(ndf != null) {
+								Toast.makeText(getActivity(),newItemsCount + " " + getString(R.string.message_bar_new_articles_available),Toast.LENGTH_LONG).show();
+								//ndf.reloadAdapterFromScratch();
+								ndf.UpdateCurrentRssView(getActivity(), true);
+							}
                         }
 						}
 					});
@@ -224,8 +222,6 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 	//AsyncUpdateFinished asyncUpdateFinished;
 	ServiceConnection mConnection = null;
 
-    private BaseMessage.OnMessageClickListener mListener = null;
-
 	/**
 	 * Mandatory empty constructor for the fragment manager to instantiate the
 	 * fragment (e.g. upon screen orientation changes).
@@ -236,33 +232,6 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
-		try
-		{
-            mListener = new BaseMessage.OnMessageClickListener()
-            {
-                @Override
-                public void onButton2Click(Parcelable data)
-                {
-                }
-
-                @Override
-                public void onButton1Click(Parcelable data)
-                {
-                    //Toast.makeText(getActivity(), "button 1 pressed", 3000).show();
-
-                    NewsReaderDetailFragment ndf = ((NewsReaderDetailFragment) getActivity().getSupportFragmentManager().findFragmentById(R.id.content_frame));
-                    if(ndf != null) {
-                        //ndf.reloadAdapterFromScratch();
-                        ndf.UpdateCurrentRssView(getActivity(), true);
-                    }
-                }
-            };
-		}
-		catch(Exception ex)
-		{
-			ex.printStackTrace();
-		}
 	}
 
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
-include ':News-Android-App', ':MessageBar', ':ownCloud-Account-Importer'
+include ':News-Android-App', ':ownCloud-Account-Importer'
 include ':Changeloglib:ChangeLogLibrary'
 include ':ShowcaseView:library'
 include ':android-HoloCircularProgressBar:library'


### PR DESCRIPTION
Maybe I'm missing something, but I don't understand why the ListFragment isn't just updated when new items are found.

This PR removes the MessageBar and just shows a Toast with the number of new items and updates the ListFragment.