### PR TITLE
Podcast fixes

### DIFF
--- a/News-Android-App/build.gradle
+++ b/News-Android-App/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.4'
     compile 'com.google.code.gson:gson:2.3.1'
     compile 'com.jakewharton:butterknife:5.1.+'
-    compile 'com.sothree.slidinguppanel:library:3.0.0'
+    compile 'com.sothree.slidinguppanel:library:3.1.1'
     compile 'de.greenrobot:eventbus:2.2.1'
     compile 'de.greenrobot:greendao:1.3.7@jar'
     compile 'de.greenrobot:greendao-generator:1.3.1@jar'

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailActivity.java
@@ -448,7 +448,7 @@ public class NewsDetailActivity extends PodcastFragmentActivity {
 
             case R.id.action_tts:
                 TTSItem ttsItem = new TTSItem(rssItem.getId(), rssItem.getTitle(), rssItem.getTitle() + "\n\n " + Html.fromHtml(rssItem.getBody()).toString(), rssItem.getFeed().getFaviconUrl());
-				openTTSItem(ttsItem);
+				openMediaItem(ttsItem);
                 break;
 
             case R.id.action_ShareItem:

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderDetailFragment.java
@@ -50,7 +50,6 @@ import org.apache.commons.lang3.time.StopWatch;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
 import de.greenrobot.dao.query.LazyList;
-import de.greenrobot.event.EventBus;
 import de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter;
 import de.luhmer.owncloudnewsreader.adapter.DividerItemDecoration;
 import de.luhmer.owncloudnewsreader.adapter.NewsListRecyclerAdapter;
@@ -59,7 +58,6 @@ import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm.SORT_DIRECTION;
 import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.helper.AsyncTaskHelper;
-import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
 
 /**
  * A fragment representing a single NewsReader detail screen. This fragment is
@@ -129,8 +127,6 @@ public class NewsReaderDetailFragment extends Fragment {
     public void onResume() {
         Log.v(TAG, "onResume called!");
 
-        EventBus.getDefault().register(this);
-
         SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
         if(mPrefs.getBoolean(SettingsActivity.CB_MARK_AS_READ_WHILE_SCROLLING_STRING, false)) {
@@ -146,12 +142,6 @@ public class NewsReaderDetailFragment extends Fragment {
         onResumeCount++;
 
         super.onResume();
-    }
-
-    @Override
-    public void onPause() {
-        EventBus.getDefault().unregister(this);
-        super.onPause();
     }
 
     private RecyclerView.OnScrollListener ListScrollListener = new RecyclerView.OnScrollListener() {
@@ -205,24 +195,6 @@ public class NewsReaderDetailFragment extends Fragment {
             }
 		}
 	}
-
-    public void onEventMainThread(PodcastDownloadService.DownloadProgressUpdate downloadProgress) {
-        NewsListRecyclerAdapter nca = (NewsListRecyclerAdapter) recyclerView.getAdapter();
-        if(nca != null) {
-            LinearLayoutManager linearLayoutManager = (LinearLayoutManager) recyclerView.getLayoutManager();
-            NewsListRecyclerAdapter.downloadProgressList.put((int) downloadProgress.podcast.itemId, downloadProgress.podcast.downloadProgress);
-
-            RssItem currentRssItem;
-            for (int i = linearLayoutManager.findFirstVisibleItemPosition(); i < linearLayoutManager.findLastVisibleItemPosition(); i++) {
-                currentRssItem = nca.getItem(i);
-                if (currentRssItem.getId().equals(downloadProgress.podcast.itemId)) {
-                    int position = i - linearLayoutManager.findFirstVisibleItemPosition();
-                    nca.setDownloadPodcastProgressbar(linearLayoutManager.getChildAt(position), currentRssItem);
-                    break;
-                }
-            }
-        }
-    }
 
 	public void notifyDataSetChangedOnAdapter()
 	{

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -39,6 +39,7 @@ import de.luhmer.owncloudnewsreader.events.podcast.UpdatePodcastStatusEvent;
 import de.luhmer.owncloudnewsreader.events.podcast.VideoDoubleClicked;
 import de.luhmer.owncloudnewsreader.helper.SizeAnimator;
 import de.luhmer.owncloudnewsreader.interfaces.IPlayPausePodcastClicked;
+import de.luhmer.owncloudnewsreader.model.MediaItem;
 import de.luhmer.owncloudnewsreader.model.PodcastItem;
 import de.luhmer.owncloudnewsreader.model.TTSItem;
 import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
@@ -55,7 +56,7 @@ public class PodcastFragmentActivity extends AppCompatActivity implements IPlayP
     boolean mBound = false;
 
 
-    private static final String TAG = "PodcastSherlockFragmentActivity";
+    private static final String TAG = "PodcastFragmentActivity";
     private PodcastFragment mPodcastFragment;
 
     private EventBus eventBus;
@@ -501,30 +502,13 @@ public class PodcastFragmentActivity extends AppCompatActivity implements IPlayP
         return px;
     }
 
-    private void openPodcast(PodcastItem podcastItem) {
-        // Bind to LocalService
+    protected void openMediaItem(MediaItem mediaItem) {
         Intent intent = new Intent(this, PodcastPlaybackService.class);
-        if(!isMyServiceRunning(PodcastPlaybackService.class)) {
-            intent.putExtra(PodcastPlaybackService.PODCAST_ITEM, podcastItem);
-            startService(intent);
-        } else {
-            mPodcastPlaybackService.openFile(podcastItem);
-            loadPodcastFavIcon();
-        }
-
-        bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
-    }
-
-    protected void openTTSItem(TTSItem ttsItem) {
-        // Bind to LocalService
-        Intent intent = new Intent(this, PodcastPlaybackService.class);
-        if(!isMyServiceRunning(PodcastPlaybackService.class)) {
-            intent.putExtra(PodcastPlaybackService.TTS_ITEM, ttsItem);
-            startService(intent);
-        } else {
-            mPodcastPlaybackService.openTtsFeed(ttsItem);
-            loadPodcastFavIcon();
-        }
+        if(mediaItem instanceof TTSItem)
+            intent.putExtra(PodcastPlaybackService.TTS_ITEM, mediaItem);
+        else
+            intent.putExtra(PodcastPlaybackService.PODCAST_ITEM, mediaItem);
+        startService(intent);
 
         bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
     }
@@ -537,7 +521,7 @@ public class PodcastFragmentActivity extends AppCompatActivity implements IPlayP
         if(file.exists()) {
             podcastItem.link = file.getAbsolutePath();
 
-            openPodcast(podcastItem);
+            openMediaItem(podcastItem);
         } else if(!podcastItem.offlineCached) {
 
             AlertDialog.Builder alertDialog = new AlertDialog.Builder(this)
@@ -558,7 +542,7 @@ public class PodcastFragmentActivity extends AppCompatActivity implements IPlayP
                 alertDialog.setPositiveButton("Stream", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        openPodcast(podcastItem);
+                        openMediaItem(podcastItem);
                     }
                 });
             }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/PodcastFragmentActivity.java
@@ -34,6 +34,7 @@ import butterknife.InjectView;
 import de.greenrobot.event.EventBus;
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
 import de.luhmer.owncloudnewsreader.database.model.RssItem;
+import de.luhmer.owncloudnewsreader.events.podcast.PodcastCompletedEvent;
 import de.luhmer.owncloudnewsreader.events.podcast.RegisterVideoOutput;
 import de.luhmer.owncloudnewsreader.events.podcast.UpdatePodcastStatusEvent;
 import de.luhmer.owncloudnewsreader.events.podcast.VideoDoubleClicked;
@@ -139,6 +140,11 @@ public class PodcastFragmentActivity extends AppCompatActivity implements IPlayP
     @Override
     protected void onResume() {
         eventBus.register(this);
+
+        if(mPodcastPlaybackService != null && !mPodcastPlaybackService.isActive()) {
+            sliding_layout.setPanelHeight(0);
+            sliding_layout.setPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+        }
 
         //eventBus.post(new RegisterVideoOutput(surfaceView));
         super.onResume();
@@ -279,6 +285,12 @@ public class PodcastFragmentActivity extends AppCompatActivity implements IPlayP
             rlVideoPodcastSurfaceWrapper.removeAllViews();
         }
 
+    }
+
+    public void onEventMainThread(PodcastCompletedEvent podcastCompletedEvent) {
+        sliding_layout.setPanelHeight(0);
+        sliding_layout.setPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+        currentlyPlaying = false;
     }
 
     /*

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
@@ -99,7 +99,20 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
         }
         View view = LayoutInflater.from(parent.getContext()).inflate(layout, parent, false);
 
-        return new ViewHolder(view, titleLineCount);
+        final ViewHolder holder = new ViewHolder(view, titleLineCount);
+
+        holder.flPlayPausePodcastWrapper.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (holder.isPlaying()) {
+                    playPausePodcastClicked.pausePodcast();
+                } else {
+                    playPausePodcastClicked.openPodcast(holder.getRssItem());
+                }
+            }
+        });
+
+        return holder;
     }
 
     @Override
@@ -119,18 +132,6 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
             holder.flPlayPausePodcastWrapper.setVisibility(View.VISIBLE);
 
             holder.setPlaying(isPlaying);
-
-            holder.flPlayPausePodcastWrapper.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (isPlaying) {
-                        playPausePodcastClicked.pausePodcast();
-                    } else {
-                        playPausePodcastClicked.openPodcast(item);
-                    }
-                    holder.setPlaying(isPlaying);
-                }
-            });
 
             setDownloadPodcastProgressbar(holder.itemView, item);
         } else {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
@@ -110,36 +110,31 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
 
         holder.setStayUnread(stayUnreadItems.contains(item.getId()));
 
-        holder.setReadState(item.getRead_temp());
-        holder.setStarred(item.getStarred_temp());
-
         holder.setClickListener((RecyclerItemClickListener) activity);
 
         //Podcast stuff
-        if(holder.flPlayPausePodcastWrapper != null) {
-            if (DatabaseConnectionOrm.ALLOWED_PODCASTS_TYPES.contains(item.getEnclosureMime())) {
-                final boolean isPlaying = idOfCurrentlyPlayedPodcast == item.getId();
-                int state = (isPlaying ? 1 : -1) * android.R.attr.state_active;
-                //Enable podcast buttons in view
-                holder.flPlayPausePodcastWrapper.setVisibility(View.VISIBLE);
+        if (DatabaseConnectionOrm.ALLOWED_PODCASTS_TYPES.contains(item.getEnclosureMime())) {
+            final boolean isPlaying = idOfCurrentlyPlayedPodcast == item.getId();
+            //Enable podcast buttons in view
+            holder.flPlayPausePodcastWrapper.setVisibility(View.VISIBLE);
 
-                holder.btnPlayPausePodcast.getDrawable().setState(new int[]{state});
+            holder.setPlaying(isPlaying);
 
-                holder.flPlayPausePodcastWrapper.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        if (isPlaying) {
-                            playPausePodcastClicked.pausePodcast();
-                        } else {
-                            playPausePodcastClicked.openPodcast(item);
-                        }
+            holder.flPlayPausePodcastWrapper.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    if (isPlaying) {
+                        playPausePodcastClicked.pausePodcast();
+                    } else {
+                        playPausePodcastClicked.openPodcast(item);
                     }
-                });
+                    holder.setPlaying(isPlaying);
+                }
+            });
 
-                setDownloadPodcastProgressbar(holder.itemView, item);
-            } else {
-                holder.flPlayPausePodcastWrapper.setVisibility(View.GONE);
-            }
+            setDownloadPodcastProgressbar(holder.itemView, item);
+        } else {
+            holder.flPlayPausePodcastWrapper.setVisibility(View.GONE);
         }
     }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
@@ -19,6 +19,7 @@ import de.luhmer.owncloudnewsreader.R;
 import de.luhmer.owncloudnewsreader.SettingsActivity;
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
 import de.luhmer.owncloudnewsreader.database.model.RssItem;
+import de.luhmer.owncloudnewsreader.events.podcast.PodcastCompletedEvent;
 import de.luhmer.owncloudnewsreader.events.podcast.UpdatePodcastStatusEvent;
 import de.luhmer.owncloudnewsreader.helper.PostDelayHandler;
 import de.luhmer.owncloudnewsreader.interfaces.IPlayPausePodcastClicked;
@@ -72,6 +73,13 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
 
             Log.v(TAG, "Updating Listview - Podcast paused");
         }
+    }
+
+    public void onEventMainThread(PodcastCompletedEvent podcastCompletedEvent) {
+        idOfCurrentlyPlayedPodcast = -1;
+        notifyDataSetChanged();
+
+        Log.v(TAG, "Updating Listview - Podcast completed");
     }
 
     @Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
@@ -99,7 +99,7 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
         }
         View view = LayoutInflater.from(parent.getContext()).inflate(layout, parent, false);
 
-        return new ViewHolder(view, titleLineCount, activity);
+        return new ViewHolder(view, titleLineCount);
     }
 
     @Override

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/NewsListRecyclerAdapter.java
@@ -1,20 +1,15 @@
 package de.luhmer.owncloudnewsreader.adapter;
 
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
 import android.support.v4.app.FragmentActivity;
 import android.support.v7.widget.RecyclerView;
 import android.text.style.ForegroundColorSpan;
 import android.util.Log;
-import android.util.SparseArray;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.pascalwelsch.holocircularprogressbar.HoloCircularProgressBar;
-
-import java.io.File;
 import java.util.HashSet;
 
 import de.greenrobot.dao.query.LazyList;
@@ -26,9 +21,7 @@ import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
 import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.events.podcast.UpdatePodcastStatusEvent;
 import de.luhmer.owncloudnewsreader.helper.PostDelayHandler;
-import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import de.luhmer.owncloudnewsreader.interfaces.IPlayPausePodcastClicked;
-import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
 
 /**
  * Created by daniel on 28.06.15.
@@ -36,7 +29,6 @@ import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
 public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
     private static final String TAG = "NewsListRecyclerAdapter";
 
-    public static SparseArray<Integer> downloadProgressList = new SparseArray<>();
     private long idOfCurrentlyPlayedPodcast = -1;
 
     private LazyList<RssItem> lazyList;
@@ -133,34 +125,20 @@ public class NewsListRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
 
             holder.setPlaying(isPlaying);
 
-            setDownloadPodcastProgressbar(holder.itemView, item);
+            holder.setDownloadPodcastProgressbar();
         } else {
             holder.flPlayPausePodcastWrapper.setVisibility(View.GONE);
         }
     }
 
-    public void setDownloadPodcastProgressbar(View view, RssItem rssItem) {
-        HoloCircularProgressBar pbPodcastDownloadProgress = (HoloCircularProgressBar) view.findViewById(R.id.podcastDownloadProgress);
-
-        if(!ThemeChooser.isDarkTheme(activity)) {
-            pbPodcastDownloadProgress.setProgressBackgroundColor(view.getContext().getResources().getColor(R.color.slide_up_panel_header_background_color));
-        }
-
-        if(PodcastAlreadyCached(view.getContext(), rssItem.getEnclosureLink()))
-            pbPodcastDownloadProgress.setProgress(1);
-        else {
-            if(downloadProgressList.get(rssItem.getId().intValue()) != null) {
-                float progressInPercent = downloadProgressList.get(rssItem.getId().intValue()) / 100f;
-                pbPodcastDownloadProgress.setProgress(progressInPercent);
-            } else {
-                pbPodcastDownloadProgress.setProgress(0);
-            }
-        }
+    @Override
+    public void onViewDetachedFromWindow(ViewHolder holder) {
+        EventBus.getDefault().unregister(holder);
     }
 
-    public static boolean PodcastAlreadyCached(Context context, String podcastUrl) {
-        File file = new File(PodcastDownloadService.getUrlToPodcastFile(context, podcastUrl, false));
-        return file.exists();
+    @Override
+    public void onViewAttachedToWindow(ViewHolder holder) {
+        EventBus.getDefault().register(holder);
     }
 
     public void ChangeReadStateOfItem(ViewHolder viewHolder, boolean isChecked) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
@@ -153,8 +153,10 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
 
     public void setPlaying(boolean playing) {
         this.playing = playing;
-        int[] state = new int[]{ (playing ? 1 : -1)  * android.R.attr.state_active };
-        btnPlayPausePodcast.getDrawable().setState(state);
+        if(playing)
+            btnPlayPausePodcast.setImageResource(R.drawable.ic_action_pause);
+        else
+            btnPlayPausePodcast.setImageResource(R.drawable.ic_action_play_arrow);
     }
 
     public boolean isPlaying() {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
@@ -70,6 +70,7 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
     private static FavIconHandler favIconHandler = null;
     private final int LengthBody = 400;
     private ForegroundColorSpan bodyForegroundColor;
+    private boolean playing;
 
     public ViewHolder(View itemView, int titleLineCount) {
         super(itemView);
@@ -125,9 +126,14 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
             starImageView.setVisibility(View.GONE);
     }
 
-    public void setPlaying(boolean isPlaying) {
-        int[] state = new int[]{ (isPlaying ? 1 : -1)  * android.R.attr.state_active };
+    public void setPlaying(boolean playing) {
+        this.playing = playing;
+        int[] state = new int[]{ (playing ? 1 : -1)  * android.R.attr.state_active };
         btnPlayPausePodcast.getDrawable().setState(state);
+    }
+
+    public boolean isPlaying() {
+        return playing;
     }
 
     public RssItem getRssItem() {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
@@ -52,7 +52,7 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
     protected View colorLineFeed;
 
     @InjectView(R.id.btn_playPausePodcast)
-    ImageView btnPlayPausePodcast;
+    protected ImageView btnPlayPausePodcast;
 
     @InjectView(R.id.podcast_wrapper)
     View flPlayPausePodcastWrapper;
@@ -126,6 +126,11 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
             starImageView.setVisibility(View.GONE);
     }
 
+    public void setPlaying(boolean isPlaying) {
+        int[] state = new int[]{ (isPlaying ? 1 : -1)  * android.R.attr.state_active };
+        btnPlayPausePodcast.getDrawable().setState(state);
+    }
+
     public RssItem getRssItem() {
         return rssItem;
     }
@@ -141,6 +146,9 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
         } else {
             Log.v(TAG, "Feed not found!!!");
         }
+
+        setReadState(rssItem.getRead_temp());
+        setStarred(rssItem.getStarred_temp());
 
         setFeedColor(ColorHelper.getFeedColor(itemView.getContext(), rssItem.getFeed()));
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
@@ -26,7 +26,6 @@ import de.luhmer.owncloudnewsreader.R;
 import de.luhmer.owncloudnewsreader.database.model.RssItem;
 import de.luhmer.owncloudnewsreader.helper.ColorHelper;
 import de.luhmer.owncloudnewsreader.helper.FavIconHandler;
-import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import de.luhmer.owncloudnewsreader.services.PodcastDownloadService;
 
 /**
@@ -65,11 +64,11 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
     @InjectView(R.id.podcast_wrapper)
     View flPlayPausePodcastWrapper;
 
-     // Only in extended with webview layout
+    // only in extended layout
     @Optional @InjectView(R.id.body)
     protected TextView textViewBody;
 
-    // only in extended layout
+    // Only in extended with webview layout
     @Optional @InjectView(R.id.webView_body)
     protected WebView webView_body;
 
@@ -89,10 +88,6 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
         if(favIconHandler == null)
             favIconHandler = new FavIconHandler(itemView.getContext());
         ButterKnife.inject(this, itemView);
-        if(ThemeChooser.isDarkTheme(itemView.getContext())) {
-            if(textViewBody != null)
-                textViewBody.setTextColor(itemView.getResources().getColor(R.color.extended_listview_item_body_text_color_dark_theme));
-        }
         if(textViewSummary != null) textViewSummary.setLines(titleLineCount);
         itemView.setOnClickListener(this);
     }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/adapter/ViewHolder.java
@@ -1,6 +1,5 @@
 package de.luhmer.owncloudnewsreader.adapter;
 
-import android.app.Activity;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.support.v7.widget.RecyclerView;
@@ -72,10 +71,10 @@ public class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickL
     private final int LengthBody = 400;
     private ForegroundColorSpan bodyForegroundColor;
 
-    public ViewHolder(View itemView, int titleLineCount, Activity activity) {
+    public ViewHolder(View itemView, int titleLineCount) {
         super(itemView);
 
-        bodyForegroundColor = new ForegroundColorSpan(activity.getResources().getColor(android.R.color.secondary_text_dark));
+        bodyForegroundColor = new ForegroundColorSpan(itemView.getContext().getResources().getColor(android.R.color.secondary_text_dark));
 
         if(favIconHandler == null)
             favIconHandler = new FavIconHandler(itemView.getContext());

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/events/podcast/PodcastCompletedEvent.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/events/podcast/PodcastCompletedEvent.java
@@ -1,0 +1,7 @@
+package de.luhmer.owncloudnewsreader.events.podcast;
+
+/**
+ * Created by daniel on 18.08.15.
+ */
+public class PodcastCompletedEvent {
+}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/MediaItem.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/MediaItem.java
@@ -1,0 +1,13 @@
+package de.luhmer.owncloudnewsreader.model;
+
+import java.io.Serializable;
+
+/**
+ * Created by daniel on 29.07.15.
+ */
+public abstract class MediaItem implements Serializable {
+    public long itemId;
+    public String title;
+    public String favIcon;
+    public String link;
+}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/PodcastItem.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/PodcastItem.java
@@ -1,11 +1,9 @@
 package de.luhmer.owncloudnewsreader.model;
 
-import java.io.Serializable;
-
 /**
  * Created by David on 21.06.2014.
  */
-public class PodcastItem implements Serializable {
+public class PodcastItem extends MediaItem {
 
     public PodcastItem() {
 
@@ -21,12 +19,8 @@ public class PodcastItem implements Serializable {
         this.isVideoPodcast = isVideoPodcast;
     }
 
-    public long itemId;
-    public String title;
-    public String link;
     public String mimeType;
     public boolean offlineCached;
-    public String favIcon;
     public boolean isVideoPodcast;
 
     public Integer downloadProgress;

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/TTSItem.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/model/TTSItem.java
@@ -5,7 +5,7 @@ import java.io.Serializable;
 /**
  * Created by David on 10.01.2015.
  */
-public class TTSItem implements Serializable {
+public class TTSItem extends MediaItem {
 
     public TTSItem() {
 
@@ -18,9 +18,5 @@ public class TTSItem implements Serializable {
         this.favIcon = favIcon;
     }
 
-    public long itemId;
-    public String title;
-    public String link;
     public String text;
-    public String favIcon;
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastDownloadService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastDownloadService.java
@@ -219,4 +219,9 @@ public class PodcastDownloadService extends IntentService {
         }
         public PodcastItem podcast;
     }
+
+    public static boolean PodcastAlreadyCached(Context context, String podcastUrl) {
+        File file = new File(PodcastDownloadService.getUrlToPodcastFile(context, podcastUrl, false));
+        return file.exists();
+    }
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -52,6 +52,14 @@ public class PodcastPlaybackService extends Service implements TextToSpeech.OnIn
         return mBinder;
     }
 
+    @Override
+    public boolean onUnbind(Intent intent) {
+        if (mCurrentlyPlayingPodcast == null && mCurrentlyPlayingTTS == null) {
+            Log.v(TAG, "Stopping PodcastPlaybackService because of inactivity");
+            stopSelf();
+        }
+        return super.onUnbind(intent);
+    }
 
     public static final String PODCAST_ITEM = "PODCAST_ITEM";
     public static final String TTS_ITEM = "TTS_ITEM";
@@ -242,14 +250,18 @@ public class PodcastPlaybackService extends Service implements TextToSpeech.OnIn
     };
 
     public void onEvent(TogglePlayerStateEvent event) {
-        if ((mPlaybackType == PlaybackType.PODCAST && mMediaPlayer.isPlaying()) || //If podcast is running
-                mPlaybackType == PlaybackType.TTS && ttsController.isSpeaking()) { // or if tts is running
+        if (isPlaying()) {
             Log.v(TAG, "calling pause()");
             pause();
         } else {
             Log.v(TAG, "calling play()");
             play();
         }
+    }
+
+    private boolean isPlaying() {
+        return (mPlaybackType == PlaybackType.PODCAST && mMediaPlayer.isPlaying()) || //If podcast is running
+                mPlaybackType == PlaybackType.TTS && ttsController.isSpeaking(); // or if tts is running
     }
 
     public void onEvent(WindPodcast event) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/services/PodcastPlaybackService.java
@@ -104,6 +104,8 @@ public class PodcastPlaybackService extends Service implements TextToSpeech.OnIn
             mgr.listen(phoneStateListener, PhoneStateListener.LISTEN_NONE);
         }
 
+        podcastNotification.cancel();
+
         super.onDestroy();
     }
 

--- a/News-Android-App/src/main/res/drawable/newsreader_playpause.xml
+++ b/News-Android-App/src/main/res/drawable/newsreader_playpause.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_active="true">
-        <bitmap android:src="@drawable/ic_action_pause_dark" />
-    </item>
-    <item>
-        <bitmap android:src="@drawable/ic_action_play_arrow_dark" />
-    </item>
-</selector>

--- a/News-Android-App/src/main/res/drawable/newsreader_playpause_light.xml
+++ b/News-Android-App/src/main/res/drawable/newsreader_playpause_light.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_active="true">
-        <bitmap android:src="@drawable/ic_action_pause" />
-    </item>
-    <item>
-        <bitmap android:src="@drawable/ic_action_play_arrow" />
-    </item>
-</selector>

--- a/News-Android-App/src/main/res/layout/subscription_detail_list_item_extended.xml
+++ b/News-Android-App/src/main/res/layout/subscription_detail_list_item_extended.xml
@@ -105,6 +105,7 @@
             android:layout_height="wrap_content"
             android:ellipsize="end"
             tools:text="Body"
+            android:textColor="?attr/extended_listview_item_body_text_color"
             android:textSize="14sp"
             android:autoLink="none"
             android:layout_below="@+id/summary"

--- a/News-Android-App/src/main/res/layout/subscription_detail_list_item_podcast_wrapper.xml
+++ b/News-Android-App/src/main/res/layout/subscription_detail_list_item_podcast_wrapper.xml
@@ -12,7 +12,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:src="?attr/playpauseDrawable" />
+        android:tint="?attr/tintColor"
+        android:src="@drawable/ic_action_pause" />
 
     <com.pascalwelsch.holocircularprogressbar.HoloCircularProgressBar
         android:id="@+id/podcastDownloadProgress"

--- a/News-Android-App/src/main/res/values/attrs.xml
+++ b/News-Android-App/src/main/res/values/attrs.xml
@@ -6,6 +6,8 @@
     <attr name="rssItemListBackground" format="color" />
     <attr name="starredColor" format="color" />
 
+    <attr name="extended_listview_item_body_text_color" format="color" />
+
     <attr name="markasreadDrawable" format="reference" />
     <attr name="starredDrawable" format="reference" />
 

--- a/News-Android-App/src/main/res/values/attrs.xml
+++ b/News-Android-App/src/main/res/values/attrs.xml
@@ -11,6 +11,6 @@
     <attr name="markasreadDrawable" format="reference" />
     <attr name="starredDrawable" format="reference" />
 
-    <attr name="playpauseDrawable" format="reference" />
+    <attr name="tintColor" format="color" />
 
 </resources>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -14,6 +14,8 @@
 
         <item name="playpauseDrawable">@drawable/newsreader_playpause</item>
 
+        <item name="extended_listview_item_body_text_color">@color/extended_listview_item_body_text_color_dark_theme</item>
+
         <item name="starredColor">@color/starredColorDark</item>
         <item name="markasreadDrawable">@drawable/swipe_markasread</item>
         <item name="starredDrawable">@drawable/swipe_setstarred</item>
@@ -36,8 +38,9 @@
         <item name="dividerLineColor">#1e000000</item>
         <item name="rssItemListBackground">#ffdedede</item>
 
-
         <item name="playpauseDrawable">@drawable/newsreader_playpause_light</item>
+
+        <item name="extended_listview_item_body_text_color">@color/extended_listview_item_body_text_color_light_theme</item>
 
         <item name="starredColor">@color/starredColorLight</item>
         <item name="markasreadDrawable">@drawable/swipe_markasread_light</item>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -9,10 +9,10 @@
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
 
+        <item name="tintColor">@android:color/white</item>
+
         <item name="dividerLineColor">#1effffff</item>
         <item name="rssItemListBackground">@color/material_grey_900</item>
-
-        <item name="playpauseDrawable">@drawable/newsreader_playpause</item>
 
         <item name="extended_listview_item_body_text_color">@color/extended_listview_item_body_text_color_dark_theme</item>
 
@@ -29,6 +29,8 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDarkLightTheme</item>
         <item name="colorAccent">@color/colorAccentLightTheme</item>
 
+        <item name="tintColor">@android:color/black</item>
+
         <item name="android:textColor">#000</item>
         <!-- <item name="android:textColorSecondary">@color/slider_listview_text_color_dark_theme</item> -->
 
@@ -37,8 +39,6 @@
 
         <item name="dividerLineColor">#1e000000</item>
         <item name="rssItemListBackground">#ffdedede</item>
-
-        <item name="playpauseDrawable">@drawable/newsreader_playpause_light</item>
 
         <item name="extended_listview_item_body_text_color">@color/extended_listview_item_body_text_color_light_theme</item>
 


### PR DESCRIPTION
Some fixes and improvements:

* Fixes a NPE when starting a podcast while the podcast service is already running
* Move more UI stuff into the ViewHolder
* Stop the PodcastPlaybackService when not playing anything (similar to OwncloudSyncService)
* Use Drawables for the play/pause button instead of Drawable states, turns out this is more reliable. This now uses Drawable tinting to adapt to the light/dark theme.
* Remove the Podcast elements from the UI when the Podcast/TTS is finished. (Collapse the PodcastFragment and remove the slider from the bottom)