### PR TITLE
Set news detail view's background color according to theme.

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
@@ -212,6 +212,10 @@ public class NewsDetailFragment extends Fragment {
 	@SuppressLint("SetJavaScriptEnabled")
 	private void init_webView()
 	{
+        int backgroundColor = ColorHelper.getColorFromAttribute(getContext(),
+                R.attr.news_detail_background_color);
+        mWebView.setBackgroundColor(backgroundColor);
+
 		WebSettings webSettings = mWebView.getSettings();
 	    //webSettings.setPluginState(WebSettings.PluginState.ON);
 	    webSettings.setJavaScriptEnabled(true);

--- a/News-Android-App/src/main/res/values/attrs.xml
+++ b/News-Android-App/src/main/res/values/attrs.xml
@@ -13,4 +13,6 @@
 
     <attr name="tintColor" format="color" />
 
+    <attr name="news_detail_background_color" format="color" />
+
 </resources>

--- a/News-Android-App/src/main/res/values/colors.xml
+++ b/News-Android-App/src/main/res/values/colors.xml
@@ -23,6 +23,10 @@
 
     <color name="material_blue_900">#0d47a1</color>
 
+    <!-- see also assets/web.css -->
+    <color name="news_detail_background_color_light_theme">#eeeeee</color>
+    <color name="news_detail_background_color_dark_theme">#222222</color>
+
 
 
     <color name="owncloudBlueLight">#35537A</color>

--- a/News-Android-App/src/main/res/values/themes.xml
+++ b/News-Android-App/src/main/res/values/themes.xml
@@ -19,6 +19,8 @@
         <item name="starredColor">@color/starredColorDark</item>
         <item name="unstarredColor">@color/unstarredColorDark</item>
         <item name="markasreadDrawable">@drawable/swipe_markasread</item>
+
+        <item name="news_detail_background_color">@color/news_detail_background_color_dark_theme</item>
     </style>
 
 
@@ -45,6 +47,8 @@
         <item name="starredColor">@color/starredColorLight</item>
         <item name="unstarredColor">@color/unstarredColorLight</item>
         <item name="markasreadDrawable">@drawable/swipe_markasread_light</item>
+
+        <item name="news_detail_background_color">@color/news_detail_background_color_light_theme</item>
     </style>
 
     <style name="ToolbarTheme" parent="ThemeOverlay.AppCompat.Dark.ActionBar">


### PR DESCRIPTION
This change is only visible while the content is still loading.
Fixes #426.