### PR TITLE
ui and ux enhancements regarding NewsDetail-ContextDialog

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
@@ -351,20 +351,19 @@ public class NewsDetailFragment extends Fragment {
                         String imgaltval = "";
                         String imgsrcval = "";
 
+                        Elements imgtag = htmldoc.getElementsByAttributeValueContaining("src", imageUrl);
                         try {
-                            Elements imgtag = htmldoc.getElementsByAttributeValueContaining("src", imageUrl);
                             imgaltval = imgtag.first().attr("alt");
                             imgsrcval = imageUrl.substring(imageUrl.lastIndexOf('/') + 1, imageUrl.length());
                             mImageUrl = new URL(imageUrl);
                         } catch (MalformedURLException e) {
                             return;
+                        } catch (NullPointerException e) {
+                            return;
                         }
 
                         String title = imgsrcval;
                         int titleIcon = android.R.drawable.ic_menu_gallery;
-                        //if(!imgsrcval.equals(imgaltval) && imgaltval.length() > 0) {
-                        //    titleIcon = android.R.drawable.ic_menu_info_details;
-                        //}
                         String text = imgaltval;
 
 

--- a/News-Android-App/src/main/res/layout/fragment_dialog_image.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_image.xml
@@ -1,65 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--  -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="@dimen/activity_vertical_margin"
-    android:paddingBottom="@dimen/activity_vertical_margin"
-    android:paddingRight="@dimen/activity_horizontal_margin">
+    android:paddingBottom="6dp"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin">
 
     <RelativeLayout
-        android:paddingLeft="@dimen/activity_horizontal_margin"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingLeft="0dp"
+        android:layout_marginBottom="4dp"
         android:id="@+id/title_wrapper">
 
-    <ImageView
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:id="@+id/ic_menu_gallery"/>
+        <ImageView
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:id="@+id/ic_menu_gallery"/>
 
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/ic_menu_title"
-        android:layout_marginLeft="5dp"
-        android:text="Sample1"
-        android:layout_centerVertical="true"
-        android:textSize="17sp"
-        android:textColor="@color/slider_listview_text_color_dark_theme"
-        android:layout_toRightOf="@+id/ic_menu_gallery"
-        android:layout_toEndOf="@+id/ic_menu_gallery"/>
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="0dp"
+            android:id="@+id/ic_menu_title"
+            android:text="Sample1"
+            android:layout_centerVertical="true"
+            android:textSize="16sp"
+            android:textColor="@color/slider_listview_text_color_dark_theme"
+            android:layout_toRightOf="@+id/ic_menu_gallery"
+            android:layout_toEndOf="@+id/ic_menu_gallery"/>
 
     </RelativeLayout>
 
     <TextView
-        android:paddingLeft="@dimen/activity_horizontal_margin"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingLeft="6dp"
         android:id="@+id/ic_menu_item_text"
-        android:layout_marginTop="10dp"
-        android:text="Sample2"
-        android:textSize="18sp"
+        android:text="Sample1"
+        android:textSize="14sp"
         android:textColor="@color/options_menu_item_text"
-        android:layout_below="@+id/title_wrapper" />
+        android:layout_below="@+id/title_wrapper"
+        android:textStyle="normal"/>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginLeft="0dp"
+        android:layout_marginRight="0dp"
         android:background="#50ffffff"
-        android:layout_below="@+id/ic_menu_item_text"
-        android:layout_marginTop="8dp"
-        android:layout_marginLeft="@dimen/activity_horizontal_margin"
-        />
+        android:layout_below="@+id/ic_menu_item_text"/>
 
     <ListView
-        android:layout_marginTop="10dp"
-        android:divider="#0000"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginLeft="-1dp"
+        android:layout_marginTop="12dp"
+        android:paddingLeft="0dp"
         android:id="@+id/ic_menu_item_list"
         android:layout_below="@+id/ic_menu_item_text">
-
     </ListView>
 
 </RelativeLayout>

--- a/News-Android-App/src/main/res/values-cs-rCZ/strings.xml
+++ b/News-Android-App/src/main/res/values-cs-rCZ/strings.xml
@@ -68,8 +68,8 @@
   <string name="action_shareimg">Sdílet obrázek</string>
   <string name="action_openimg">Otevřít obrázek v prohlížeči</string>
   <string name="toast_img_download_wait">Stahuji... chvíli strpení</string>
-  <string name="toast_imgsaved">Obrázek uložen.</string>
-  <string name="toast_notwriteable">Selhalo zapsání obrázku.</string>
+  <string name="toast_img_saved">Obrázek uložen.</string>
+  <string name="toast_img_notwriteable">Selhalo zapsání obrázku.</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Uživatelské jméno</string>
   <string name="pref_title_password">Heslo</string>

--- a/News-Android-App/src/main/res/values-fi-rFI/strings.xml
+++ b/News-Android-App/src/main/res/values-fi-rFI/strings.xml
@@ -59,8 +59,8 @@
   <string name="action_shareimg">Jaa kuva</string>
   <string name="action_openimg">Avaa kuva selaimessa</string>
   <string name="toast_img_download_wait">Ladataan, odota hetki...</string>
-  <string name="toast_imgsaved">Kuva tallennettu.</string>
-  <string name="toast_notwriteable">Kuvan tallennus epäonnistui.</string>
+  <string name="toast_img_saved">Kuva tallennettu.</string>
+  <string name="toast_img_notwriteable">Kuvan tallennus epäonnistui.</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Käyttäjätunnus</string>
   <string name="pref_title_password">Salasana</string>

--- a/News-Android-App/src/main/res/values-fr/strings.xml
+++ b/News-Android-App/src/main/res/values-fr/strings.xml
@@ -64,8 +64,8 @@
   <string name="action_shareimg">Partager l\'Image</string>
   <string name="action_openimg">Ouvrir l\'Image dans le navigateur</string>
   <string name="toast_img_download_wait">Téléchargement... Veuillez patienter</string>
-  <string name="toast_imgsaved">Image sauvegardée.</string>
-  <string name="toast_notwriteable">Erreur d\'écriture de l\'Image.</string>
+  <string name="toast_img_saved">Image sauvegardée.</string>
+  <string name="toast_img_notwriteable">Erreur d\'écriture de l\'Image.</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Nom d\'utilisateur</string>
   <string name="pref_title_password">Mot de passe</string>

--- a/News-Android-App/src/main/res/values-it/strings.xml
+++ b/News-Android-App/src/main/res/values-it/strings.xml
@@ -64,8 +64,8 @@
   <string name="action_shareimg">Condividi immagine</string>
   <string name="action_openimg">Apri immagine nel browser</string>
   <string name="toast_img_download_wait">Scaricamento in corso... attendi</string>
-  <string name="toast_imgsaved">Immagine salvata.</string>
-  <string name="toast_notwriteable">Scrittura dell\'immagine non riuscita.</string>
+  <string name="toast_img_saved">Immagine salvata.</string>
+  <string name="toast_img_notwriteable">Scrittura dell\'immagine non riuscita.</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Nome utente</string>
   <string name="pref_title_password">Password</string>

--- a/News-Android-App/src/main/res/values-ja-rJP/strings.xml
+++ b/News-Android-App/src/main/res/values-ja-rJP/strings.xml
@@ -60,8 +60,8 @@
   <string name="action_shareimg">画像を共有</string>
   <string name="action_openimg">画像をブラウザーで開く</string>
   <string name="toast_img_download_wait">ダウンロード中...しばらくお待ちください</string>
-  <string name="toast_imgsaved">画像を保存しました。</string>
-  <string name="toast_notwriteable">画像の書き込みに失敗しました。</string>
+  <string name="toast_img_saved">画像を保存しました。</string>
+  <string name="toast_img_notwriteable">画像の書き込みに失敗しました。</string>
   <!--Strings related to login-->
   <string name="pref_title_username">ユーザー名</string>
   <string name="pref_title_password">パスワード</string>

--- a/News-Android-App/src/main/res/values-nl/strings.xml
+++ b/News-Android-App/src/main/res/values-nl/strings.xml
@@ -64,8 +64,8 @@
   <string name="action_shareimg">Delen afbeelding</string>
   <string name="action_openimg">Open afbeelding in browser</string>
   <string name="toast_img_download_wait">Downloaden... even geduld</string>
-  <string name="toast_imgsaved">Afbeelding opgeslagen</string>
-  <string name="toast_notwriteable">Opslaan afbeelding mislukt</string>
+  <string name="toast_img_saved">Afbeelding opgeslagen</string>
+  <string name="toast_img_notwriteable">Opslaan afbeelding mislukt</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Gebruikersnaam</string>
   <string name="pref_title_password">Wachtwoord</string>

--- a/News-Android-App/src/main/res/values-pt-rBR/strings.xml
+++ b/News-Android-App/src/main/res/values-pt-rBR/strings.xml
@@ -64,8 +64,8 @@
   <string name="action_shareimg">Compartilhar Imagem</string>
   <string name="action_openimg">Abrir Imagem no Navegador</string>
   <string name="toast_img_download_wait">Baixando... por favor aguarde</string>
-  <string name="toast_imgsaved">Imagem salva.</string>
-  <string name="toast_notwriteable">Falhou ao salvar Imagem</string>
+  <string name="toast_img_saved">Imagem salva.</string>
+  <string name="toast_img_notwriteable">Falhou ao salvar Imagem</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Nome de Usuário</string>
   <string name="pref_title_password">Senha</string>

--- a/News-Android-App/src/main/res/values-pt-rPT/strings.xml
+++ b/News-Android-App/src/main/res/values-pt-rPT/strings.xml
@@ -61,7 +61,7 @@
   </plurals>
   <!--ContextMenu Items-->
   <string name="action_shareimg">Partilhar imagem</string>
-  <string name="toast_imgsaved">Imagem guardada.</string>
+  <string name="toast_img_saved">Imagem guardada.</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Nome de utilizador</string>
   <string name="pref_title_password">Palavra-passe:</string>

--- a/News-Android-App/src/main/res/values-sq/strings.xml
+++ b/News-Android-App/src/main/res/values-sq/strings.xml
@@ -64,8 +64,8 @@
   <string name="action_shareimg">Ndajeni Figurën Me të Tjerë</string>
   <string name="action_openimg">Hapeni Figurën në shfletues</string>
   <string name="toast_img_download_wait">Po shkarkohet… ju lutemi, pritni</string>
-  <string name="toast_imgsaved">Figura u ruajt.</string>
-  <string name="toast_notwriteable">Dështoi shkrimi i Figurës.</string>
+  <string name="toast_img_saved">Figura u ruajt.</string>
+  <string name="toast_img_notwriteable">Dështoi shkrimi i Figurës.</string>
   <!--Strings related to login-->
   <string name="pref_title_username">Emër përdoruesi</string>
   <string name="pref_title_password">Fjalëkalim</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -65,15 +65,20 @@
         <item quantity="other">%d new unread items available</item>
     </plurals>
 
-    <!-- ContextMenu Items -->
-    <string name="action_downloadimg">Download Image</string>
-    <string name="action_shareimg">Share Image</string>
-    <string name="action_openimg">Open Image in browser</string>
-
+    <!-- String related to NewsDetail-ContextMenu Items -->
+    <string name="action_img_download">Download Image</string>
+    <string name="action_img_sharelink">Share Image Link</string>
+    <string name="action_img_open">Open Image in Browser</string>
+    <string name="action_img_copylink">Copy Image Link</string>
+    <string name="action_link_share">Share Link</string>
+    <string name="action_link_open">Open Link in Browser</string>
+    <string name="action_link_copy">Copy Link</string>
     <string name="toast_img_download_wait">Downloading... please wait</string>
-    <string name="toast_imgsaved">Image saved.</string>
-    <string name="toast_notwriteable">Failed to write Image.</string>
-
+    <string name="toast_img_saved">Image saved.</string>
+    <string name="toast_img_notwriteable">Failed to write Image.</string>
+    <string name="toast_copied_to_clipboard">Copied to clipboard</string>
+    <string name="error_download_failed">Download failed</string>
+    <string name="intent_title_share">Share via</string>
 
     <!-- Strings related to login -->
     <string name="pref_title_username">Username</string>


### PR DESCRIPTION
##### NEW:
* improved layout of the contextDialog (margins/paddings) (see screenshots below)
* omit alt-text from dialog if empty or same as imagename (see screenshots below)
* hide the dialog immediately after "Download Image" pressed (dismiss on download-success/error)
* refactored all UI-strings to strings.xml for better internationalization
* gain control over sort-order of dialog-list-items (HashMap -> LinkedHashMap). Now, order is order of insertion (`mMenuItems.put(xyz)`), was not the case with `mMenuItems = HashMap``
* Fixed bug where app crashes when certain relative image-links appear on a website viewed in internal browser (e.g. on heise-website)


##### TO DO:
* Colors of dialog and items do not follow the different themes (dark/light) correctly.
 (Should it??? the OptionsMenu (top-right) also stays dark in light-theme... on purpose?)


![andr-4 4_mi4_compare](https://cloud.githubusercontent.com/assets/1008399/11189445/64dea64e-8c90-11e5-8c14-2a8ddf0eae1e.png)
`Android KitKat 4.4.4:  before – after`
`a slightly clearer, more harmonic arrangement`


![andr-6 0_nexus7-compare](https://cloud.githubusercontent.com/assets/1008399/11189509/bf99aea8-8c90-11e5-8426-62b3236da2c1.png)

`Android Marshmallow 6.0:  before – after`
`Alt-Text is omitted because it's identical to Image-Filename`



The numerous language-string.xml-file are in the commit, because i refactor-renamed a key-name. Not sure whether they should have been committed here?!