### PR TITLE
Android lint fixes

### DIFF
--- a/News-Android-App/src/main/res/layout/activity_new_feed.xml
+++ b/News-Android-App/src/main/res/layout/activity_new_feed.xml
@@ -41,7 +41,7 @@
                     android:id="@+id/et_feed_url"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Feed URL"
+                    android:hint="@string/hint_feed_url"
                     android:inputType="textUri"
                     android:maxLines="1"
                     android:singleLine="true"/>
@@ -57,7 +57,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="16dp"
-                    android:text="Add feed"
+                    android:text="@string/action_add_feed"
                     android:textStyle="bold"/>
 
             </LinearLayout>

--- a/News-Android-App/src/main/res/layout/fragment_dialog_image.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_image.xml
@@ -2,6 +2,7 @@
 
 <!--  -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -28,7 +29,7 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="5dp"
             android:id="@+id/ic_menu_title"
-            android:text="Sample1"
+            tools:text="Sample1"
             android:layout_centerVertical="true"
             android:textSize="16sp"
             android:textStyle="bold"
@@ -42,7 +43,7 @@
         android:layout_height="wrap_content"
         android:paddingLeft="6dp"
         android:id="@+id/ic_menu_item_text"
-        android:text="Sample1"
+        tools:text="Sample1"
         android:textSize="14sp"
         android:layout_marginTop="2dp"
         android:layout_below="@+id/title_wrapper"

--- a/News-Android-App/src/main/res/layout/fragment_podcast.xml
+++ b/News-Android-App/src/main/res/layout/fragment_podcast.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/slideupframe"
     android:orientation="vertical"
     android:layout_width="match_parent"
@@ -73,14 +74,14 @@
                         android:layout_width="0dp"
                         android:layout_weight="1"
                         android:layout_height="wrap_content"
-                        android:text="00:00"
+                        tools:text="00:00"
                         android:textColor="@color/slider_listview_text_color_dark_theme" />
 
                     <TextView
                         android:id="@+id/tv_to"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="00:00"
+                        tools:text="00:00"
                         android:textColor="@color/slider_listview_text_color_dark_theme" />
                 </LinearLayout>
 
@@ -126,7 +127,7 @@
                 android:textStyle="bold"
                 android:ellipsize="end"
                 android:maxLines="2"
-                android:text="No title selected"
+                android:text="@string/no_podcast_selected"
                 android:textSize="18sp" />
 
             <!--
@@ -193,7 +194,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:text="No chapters available"
+            android:text="@string/no_chapters_available"
             android:textSize="18sp"
             android:textColor="@color/divider_row_color_dark_theme"/>
 
@@ -246,7 +247,7 @@
                 android:id="@+id/tv_fromSlider"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="00:00"
+                tools:text="00:00"
                 android:layout_gravity="center_vertical" />
 
 
@@ -280,7 +281,7 @@
                 android:id="@+id/tv_ToSlider"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="00:00"
+                tools:text="00:00"
                 android:layout_gravity="center_vertical" />
 
         </LinearLayout>

--- a/News-Android-App/src/main/res/layout/podcast_feed_row.xml
+++ b/News-Android-App/src/main/res/layout/podcast_feed_row.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="70dp"
@@ -13,7 +14,7 @@
         android:layout_height="wrap_content"
         android:textSize="18sp"
         android:textStyle="bold"
-        android:text="Large Text"
+        tools:text="Large Text"
         android:singleLine="true"
         android:textColor="#ff161616"
         android:ellipsize="end" />
@@ -26,6 +27,6 @@
         android:layout_height="wrap_content"
         android:textSize="16sp"
         android:textColor="#ff161616"
-        android:text="3 Podcasts verfügbar!" />
+        tools:text="3 Podcasts verfügbar!" />
 
 </LinearLayout>

--- a/News-Android-App/src/main/res/layout/podcast_row.xml
+++ b/News-Android-App/src/main/res/layout/podcast_row.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -22,7 +23,7 @@
             android:layout_height="40dp"
             android:textSize="16sp"
             android:textStyle="bold"
-            android:text="Large Tex dfs hysjd kfhsakj lfhjdaksl fh"
+            tools:text="Large text - this is a very long line of text and may break."
             android:textColor="#ff161616"
             android:ellipsize="end"
             android:maxLines="2" />
@@ -33,7 +34,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="15sp"
-            android:text="3 Podcasts verfügbar!"
+            tools:text="3 podcasts available!"
             android:textColor="#ff161616" />
 
 
@@ -56,7 +57,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="match_parent"
                 android:layout_marginLeft="10dp"
-                android:text="100%"
+                tools:text="100%"
                 android:gravity="center_vertical"
                 android:textColor="#ff161616"/>
         </LinearLayout>

--- a/News-Android-App/src/main/res/layout/widget_item.xml
+++ b/News-Android-App/src/main/res/layout/widget_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="50dp"
     android:orientation="horizontal"
@@ -49,7 +50,7 @@
             android:gravity="center_vertical"
             android:singleLine="true"
             android:textIsSelectable="false"
-            android:text="Item title"
+            tools:text="Item title"
             android:ellipsize="end"
             android:textStyle="bold"
             android:textSize="16sp"
@@ -65,7 +66,7 @@
             android:layout_marginRight="10dp"
             android:singleLine="true"
             android:textIsSelectable="false"
-            android:text="07.08.14 19:00"
+            tools:text="07.08.14 19:00"
             android:textSize="14sp" />
 
         <TextView
@@ -77,7 +78,7 @@
             android:layout_alignParentLeft="true"
             android:singleLine="true"
             android:textIsSelectable="false"
-            android:text="Feed name"
+            tools:text="Feed name"
             android:textSize="14sp" />
 
 

--- a/News-Android-App/src/main/res/menu/news_reader.xml
+++ b/News-Android-App/src/main/res/menu/news_reader.xml
@@ -1,4 +1,5 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
+<menu xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/menu_update"
@@ -55,7 +56,8 @@
         app:showAsAction="never"
         android:orderInCategory="103"
         android:title="Create Database Dump"
-        android:visible="false"/>
+        android:visible="false"
+        tools:ignore="HardcodedText" />
 
 
 </menu>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -19,7 +19,6 @@
     <string name="allUnreadFeeds">All unread items</string>
     <string name="starredFeeds">Starred items</string>
     <string name="title_activity_new_feed">Add new feed</string>
-    <!-- <string name="non_sorted_articles">Nicht zugeordnete Artikel</string> -->
 
     <string name="menu_update">Refresh</string>
     <string name="menu_About_Changelog">About / Changelog</string>
@@ -27,8 +26,6 @@
     <string name="menu_StartImageCaching">Download images</string>
     <string name="menu_downloadMoreItems">Download more items</string>
 
-    <!-- Import Accounts -->
-    <string name="import_account">Import Account</string>
 
     <!-- Action Bar Items -->
     <string name="action_starred">Starred</string>
@@ -51,9 +48,11 @@
         <item quantity="other">%d new unread items available</item>
     </plurals>
 
+
     <!-- Add new feed -->
     <string name="hint_feed_url">Feed URL</string>
     <string name="action_add_feed">Add feed</string>
+
 
     <!-- String related to NewsDetail-ContextMenu Items -->
     <string name="action_img_download">Download Image</string>
@@ -70,17 +69,22 @@
     <string name="error_download_failed">Download failed</string>
     <string name="intent_title_share">Share via</string>
 
+
     <!-- Strings related to login -->
     <string name="pref_title_username">Username</string>
     <string name="pref_title_password">Password</string>
     <string name="pref_title_owncloudRootPath">ownCloud root address</string>
     <string name="pref_default_owncloudRootPath">https://1.2.3.4/owncloud</string>
-    <!-- <string name="pref_default_username">admin</string> -->
 
     <string name="action_sign_in_short">Sign in</string>
     <string name="login_progress_signing_in">Signing in…</string>
     <string name="error_field_required">This field is required</string>
     <string name="error_invalid_url">This url is incorrect</string>
+
+
+    <!-- Import Accounts -->
+    <string name="import_account">Import Account</string>
+
 
     <!-- Toast Messages -->
     <plurals name="toast_downloaded_x_items">
@@ -93,9 +97,11 @@
         <item quantity="other">Fetched %d items so far…</item>
     </plurals>
 
+
     <!-- Strings related to Settings -->
     <string name="title_activity_settings">Settings</string>
     <string name="cache_is_cleared">Cache is cleared!</string>
+
 
     <!-- General settings -->
     <string name="pref_header_general">General</string>
@@ -109,18 +115,6 @@
         <item>1</item>
         <item>0</item>
     </string-array>
-    <!--
-    <string-array name="pref_general_sort_order_values">
-        <item>desc</item>
-        <item>asc</item>
-	</string-array>
-    -->
-
-
-    <!--
-    <string name="pref_title_social_recommendations">Enable social recommendations</string>
-    <string name="pref_description_social_recommendations">Recommendations for people to contact based on your message history</string>
-    -->
 
     <string name="dialog_clearing_cache">Clearing cache</string>
     <string name="dialog_clearing_cache_please_wait">Clearing cache… Please wait.</string>
@@ -128,12 +122,11 @@
     <string name="warning">Warning</string>
     <string name="pref_title_AutoSyncOnStart">Sync on startup</string>
     <string name="pref_title_ShowOnlyUnread">Show only unread articles</string>
-    <!-- <string name="pref_title_AllowAllSSLCertificates">Allow all SSL Certificates</string> -->
     <string name="pref_title_DisableHostnameVerification">Disable Hostname Verification</string>
     <string name="pref_title_NavigateWithVolumeButtons">Navigate with volume buttons</string>
     <string name="pref_title_MarkAsReadWhileScrolling">Mark as read while scrolling</string>
     <string name="pref_title_OpenInBrowserDirectly">Use external browser to view articles</string>
-    <string name="pref_title_notification_new_articles_available">Show notification when new articles are available</string>
+
 
     <!-- MemorizingTrustManager -->
     <string name="mtm_accept_cert">Accept Unknown Certificate?</string>
@@ -145,7 +138,6 @@
     <!-- Podcast -->
     <string name="no_podcast_selected">No podcast selected</string>
     <string name="no_chapters_available">No chapters available</string>
-
 
 
     <!-- Settings for Display -->
@@ -187,6 +179,12 @@
         <item>4</item>
     </string-array>
 
+
+    <!-- Settings for Notifications -->
+    <string name="pref_header_notifications">Notifications</string>
+    <string name="pref_title_notification_new_articles_available">Show notification when new articles are available</string>
+
+
     <!-- Login Dialog -->
     <string name="login_dialog_title_error">Error</string>
     <string name="login_dialog_text_something_went_wrong">Something went wrong :(</string>
@@ -194,13 +192,12 @@
     <string name="login_dialog_title_security_warning">Security Warning</string>
     <string name="login_dialog_text_security_warning">You\'re not using https. An attacker could intercept your traffic and gain access to some sensitive data (e.g. your password). So it\'s strongly recommend to use https!</string>
 
+
     <!-- Data & Sync -->
     <string name="pref_header_data_sync">Data &amp; sync</string>
-    <!-- <string name="pref_title_data_sync_max_items">Max number of items to sync</string> -->
     <string name="pref_title_clearCache">Clear cache</string>
     <string name="pref_title_CacheImagesOffline">Cache images offline</string>
     <string name="pref_title_Max_Cache_Size">Max Cache Size</string>
-
 
     <string-array name="pref_data_sync_image_cache">
         <item>Never</item>
@@ -258,37 +255,6 @@
         <item>1440</item>
     </string-array>
 
-    <!--
-    <string name="pref_title_sync_frequency">Sync frequency</string>
-
-    <string-array name="pref_sync_frequency_titles">
-        <item>15 minutes</item>
-        <item>30 minutes</item>
-        <item>1 hour</item>
-        <item>3 hours</item>
-        <item>6 hours</item>
-        <item>Never</item>
-    </string-array>
-    <string-array name="pref_sync_frequency_values">
-        <item>15</item>
-        <item>30</item>
-        <item>60</item>
-        <item>180</item>
-        <item>360</item>
-        <item>-1</item>
-    </string-array>
-    -->
-
-
-    <!-- <string name="pref_title_system_sync_settings">System sync settings</string> -->
-
-    <string name="pref_header_notifications">Notifications</string>
-    <!--
-    <string name="pref_title_new_message_notifications">New message notifications</string>
-    <string name="pref_title_ringtone">Ringtone</string>
-    <string name="pref_ringtone_silent">Silent</string>
-    <string name="pref_title_vibrate">Vibrate</string>
-    -->
 
     <!-- content description for images and icons -->
     <string name="content_desc_none">@null</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -51,6 +51,10 @@
         <item quantity="other">%d new unread items available</item>
     </plurals>
 
+    <!-- Add new feed -->
+    <string name="hint_feed_url">Feed URL</string>
+    <string name="action_add_feed">Add feed</string>
+
     <!-- String related to NewsDetail-ContextMenu Items -->
     <string name="action_img_download">Download Image</string>
     <string name="action_img_sharelink">Share Image Link</string>
@@ -140,6 +144,7 @@
 
     <!-- Podcast -->
     <string name="no_podcast_selected">No podcast selected</string>
+    <string name="no_chapters_available">No chapters available</string>
 
 
 
@@ -287,7 +292,6 @@
 
     <!-- content description for images and icons -->
     <string name="content_desc_none">@null</string>
-    <string name="content_desc_feed_icon">feed icon</string>
     <string name="content_desc_play">play</string>
     <string name="content_desc_pause">pause</string>
     <string name="content_desc_rewind">rewind</string>


### PR DESCRIPTION
There was hardcoded text left in some layouts. I pulled it into strings.xml so it can be translated or marked it with the ```tools``` prefix when it's just used for the layout view inside Android Studio.