### PR TITLE
Enabled web storage inside webview to fix mobile redirect at heise.de

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
@@ -225,24 +225,13 @@ public class NewsDetailFragment extends Fragment {
         mWebView.setBackgroundColor(backgroundColor);
 
 		WebSettings webSettings = mWebView.getSettings();
-	    //webSettings.setPluginState(WebSettings.PluginState.ON);
 	    webSettings.setJavaScriptEnabled(true);
 	    webSettings.setAllowFileAccess(true);
-	    //webSettings.setPluginsEnabled(true);
-	    //webSettings.setDomStorageEnabled(true);
-
+	    webSettings.setDomStorageEnabled(true);
 	    webSettings.setJavaScriptCanOpenWindowsAutomatically(false);
 	    webSettings.setSupportMultipleWindows(false);
 	    webSettings.setSupportZoom(false);
-	    //webSettings.setRenderPriority(WebSettings.RenderPriority.HIGH);
-	    //webSettings.setSavePassword(false);
-	    //webview.setVerticalScrollBarEnabled(false);
-	    //webview.setHorizontalScrollBarEnabled(false);
         webSettings.setAppCacheEnabled(true);
-        //webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
-        //webSettings.setAppCacheMaxSize(200);
-        //webSettings.setDatabaseEnabled(true);
-        //webview.clearCache(true);
 
         registerForContextMenu(mWebView);
 


### PR DESCRIPTION
Because we got many bug reports because of the broken mobile redirect. I see no security issues in enabling the web storage api.

Fixes #468, #466, #385, #471  