### PR TITLE
Excluded value arrays and references to resources from translation.

### DIFF
--- a/News-Android-App/src/main/res/values-pt-rBR/strings.xml
+++ b/News-Android-App/src/main/res/values-pt-rBR/strings.xml
@@ -215,7 +215,6 @@
     <item>1440</item>
   </string-array>
   <!--content description for images and icons-->
-  <string name="content_desc_none">@nulo</string>
   <string name="content_desc_play">executar</string>
   <string name="content_desc_pause">pausa</string>
   <string name="content_desc_rewind">recarregar</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -111,7 +111,7 @@
         <item>New -> Old</item>
         <item>Old -> New</item>
     </string-array>
-    <string-array name="pref_general_sort_order_values_not_translated">
+    <string-array name="pref_general_sort_order_values_not_translated" translatable="false">
         <item>1</item>
         <item>0</item>
     </string-array>
@@ -150,7 +150,7 @@
         <item>Dark</item>
         <item>Light</item>
     </string-array>
-    <string-array name="pref_display_apptheme_values">
+    <string-array name="pref_display_apptheme_values" translatable="false">
         <item>0</item>
         <item>1</item>
     </string-array>
@@ -160,7 +160,7 @@
         <item>Extended (full text)</item>
         <item>Extended with Webview</item>
     </string-array>
-    <string-array name="pref_display_feed_list_layout_values">
+    <string-array name="pref_display_feed_list_layout_values" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>3</item>
@@ -172,7 +172,7 @@
         <item>3</item>
         <item>4</item>
     </string-array>
-    <string-array name="pref_title_lines_count_values">
+    <string-array name="pref_title_lines_count_values" translatable="false">
         <item>1</item>
         <item>2</item>
         <item>3</item>
@@ -205,7 +205,7 @@
         <item>Over WiFi &amp; Mobile</item>
         <item>Ask when not connected to WiFi</item>
     </string-array>
-    <string-array name="pref_data_sync_image_cache_values">
+    <string-array name="pref_data_sync_image_cache_values" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -221,7 +221,7 @@
         <item>5 GB</item>
         <item>10 GB</item>
     </string-array>
-    <string-array name="pref_data_sync_max_cache_size_values">
+    <string-array name="pref_data_sync_max_cache_size_values" translatable="false">
         <item>250</item>
         <item>500</item>
         <item>750</item>
@@ -242,7 +242,7 @@
         <item>12 Hours</item>
         <item>24 Hours</item>
     </string-array>
-    <string-array name="array_sync_interval_values">
+    <string-array name="array_sync_interval_values" translatable="false">
         <item>5</item>
         <item>15</item>
         <item>30</item>
@@ -257,7 +257,7 @@
 
 
     <!-- content description for images and icons -->
-    <string name="content_desc_none">@null</string>
+    <string name="content_desc_none" translatable="false">@null</string>
     <string name="content_desc_play">play</string>
     <string name="content_desc_pause">pause</string>
     <string name="content_desc_rewind">rewind</string>


### PR DESCRIPTION
They will no longer be displayed inside transifex.

The build just broke because @null has been translated (which references a resource). This should be fixed inside transifex too so the error doesn't get imported again.