### PR TITLE
New Feature: Rename and remove feeds

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ListView/SubscriptionExpandableListAdapter.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/ListView/SubscriptionExpandableListAdapter.java
@@ -249,25 +249,40 @@ public class SubscriptionExpandableListAdapter extends BaseExpandableListAdapter
         	viewHolder = (GroupHolder) convertView.getTag();
         }
 
-
         viewHolder.txt_Summary.setText(group.header);
         viewHolder.listItemLayout.setOnClickListener(new OnClickListener() {
 
-			@Override
-			public void onClick(View v) {
+            @Override
+            public void onClick(View v) {
 
-				long idFeed = group.id_database;
-				boolean skipFireEvent = false;
+                long idFeed = group.id_database;
+                boolean skipFireEvent = false;
 
-                if(group instanceof ConcreteFeedItem) {
+                if (group instanceof ConcreteFeedItem) {
                     fireListTextClicked(idFeed, false, (long) ITEMS_WITHOUT_FOLDER.getValue());
                     skipFireEvent = true;
-				}
+                }
 
-				if(!skipFireEvent)
-					fireListTextClicked(idFeed, true, ((FolderSubscribtionItem) group).idFolder);
-			}
-		});
+                if (!skipFireEvent)
+                    fireListTextClicked(idFeed, true, ((FolderSubscribtionItem) group).idFolder);
+            }
+        });
+
+        viewHolder.listItemLayout.setOnLongClickListener(new View.OnLongClickListener() {
+
+            @Override
+            public boolean onLongClick(View v) {
+
+                long idFeed = group.id_database;
+
+                if (group instanceof ConcreteFeedItem) {
+                    fireListTextLongClicked(idFeed, false, (long) ITEMS_WITHOUT_FOLDER.getValue());
+                } else {
+                    fireListTextLongClicked(idFeed, true, ((FolderSubscribtionItem) group).idFolder);
+                }
+                return true; //consume event
+            }
+        });
 
 
         viewHolder.txt_UnreadCount.setText("");
@@ -609,4 +624,9 @@ public class SubscriptionExpandableListAdapter extends BaseExpandableListAdapter
 		if(eListTextClickHandler != null)
 			eListTextClickHandler.onTextClicked(idFeed, isFolder, optional_folder_id);
 	}
+    protected void fireListTextLongClicked(long idFeed, boolean isFolder, Long optional_folder_id)
+    {
+        if(eListTextClickHandler != null)
+            eListTextClickHandler.onTextLongClicked(idFeed, isFolder, optional_folder_id);
+    }
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -583,6 +583,21 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		StartDetailFragment(idFeed, false, optional_folder_id, true);
 	}
 
+	@Override
+	public void onTopItemLongClicked(long idFeed, boolean isFolder, Long optional_folder_id) {
+		if(isFolder) {
+			//top-folder long-clicked
+		} else {
+			//top-item long-clicked
+		}
+	}
+
+	@Override
+	public void onChildItemLongClicked(long idFeed, Long optional_folder_id) {
+		//child-item long-clicked
+
+	}
+
 	private NewsReaderDetailFragment StartDetailFragment(long id, Boolean folder, Long optional_folder_id, boolean updateListView)
 	{
 		if(menuItemDownloadMoreItems != null) {

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -61,6 +61,7 @@ import android.support.v7.widget.Toolbar;
 import android.util.Base64;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -372,6 +373,9 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			drawerToggle.onConfigurationChanged(newConfig);
 	}
 
+	public void switchToAllUnreadItems() {
+		StartDetailFragment(SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue(), true, null, true);
+	}
 	public void reloadCountNumbersOfSlidingPaneAdapter() {
 		NewsReaderListFragment nlf = getSlidingListFragment();
 		if (nlf != null) {
@@ -379,7 +383,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		}
 	}
 
-	private void updateCurrentRssView() {
+	public void updateCurrentRssView() {
 		NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
 		if (ndf != null) {
 			//ndf.reloadAdapterFromScratch();
@@ -615,8 +619,8 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			String iconurl = dbConn.getFeedById(idFeed).getFaviconUrl();
 			String feedurl = dbConn.getFeedById(idFeed).getLink();
 
-			System.out.println("***********************: " + dbConn.getFeedById(idFeed).getLink());
-			DialogFragment fragment = NewsReaderListDialogFragment.newInstance(titel, iconurl, feedurl);
+			NewsReaderListDialogFragment fragment = NewsReaderListDialogFragment.newInstance(idFeed, titel, iconurl, feedurl);
+			fragment.setActivity(this);
 			fragment.show(ft, "news_reader_list_dialog");
 		}
 	}
@@ -855,8 +859,9 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if(resultCode == RESULT_OK){
-            UpdateListView();
+		if(resultCode == RESULT_OK){
+
+			UpdateListView();
 
 			getSlidingListFragment().ListViewNotifyDataSetChanged();
         }
@@ -884,11 +889,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
         }
     }
 
-	private NewsReaderListFragment getSlidingListFragment() {
+	public /*private*/ NewsReaderListFragment getSlidingListFragment() {
 		return ((NewsReaderListFragment) getSupportFragmentManager().findFragmentById(R.id.left_drawer));
 	}
 
-	private NewsReaderDetailFragment getNewsReaderDetailFragment() {
+	public NewsReaderDetailFragment getNewsReaderDetailFragment() {
 		 return (NewsReaderDetailFragment) getSupportFragmentManager().findFragmentById(R.id.content_frame);
 	}
 
@@ -897,18 +902,18 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	   	LoginDialogFragment dialog = LoginDialogFragment.getInstance();
 	   	dialog.setActivity(activity);
 	   	dialog.setListener(new LoginSuccessfullListener() {
-            @Override
-            public void LoginSucceeded() {
-                ((NewsReaderListActivity) activity).getSlidingListFragment().ReloadAdapter();
-                ((NewsReaderListActivity) activity).updateCurrentRssView();
-                ((NewsReaderListActivity) activity).startSync();
-            }
-        });
+			@Override
+			public void LoginSucceeded() {
+				((NewsReaderListActivity) activity).getSlidingListFragment().ReloadAdapter();
+				((NewsReaderListActivity) activity).updateCurrentRssView();
+				((NewsReaderListActivity) activity).startSync();
+			}
+		});
 	    dialog.show(activity.getSupportFragmentManager(), "NoticeDialogFragment");
     }
 
 
-	private void UpdateListView()
+	public /*private*/ void UpdateListView()
     {
         getNewsReaderDetailFragment().notifyDataSetChangedOnAdapter();
     }
@@ -1041,7 +1046,8 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
         }
     }
 
-    private class UserInfo implements Serializable {
+
+	private class UserInfo implements Serializable {
         private String mUserId;
         private String mDisplayName;
         private Bitmap mAvatar;

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -47,8 +47,10 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
+import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
@@ -133,14 +135,17 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	private static MenuItem menuItemUpdater;
 	private static MenuItem menuItemDownloadMoreItems;
 
-    //private Date mLastSyncDate = new Date(0);
-    private boolean mSyncOnStartupPerformed = false;
+	//private Date mLastSyncDate = new Date(0);
+	private boolean mSyncOnStartupPerformed = false;
 
-    @InjectView(R.id.toolbar) Toolbar toolbar;
+	@InjectView(R.id.toolbar)
+	Toolbar toolbar;
 
 	private ServiceConnection mConnection = null;
 
-	@Optional @InjectView(R.id.drawer_layout) protected DrawerLayout drawerLayout;
+	@Optional
+	@InjectView(R.id.drawer_layout)
+	protected DrawerLayout drawerLayout;
 
 	private ActionBarDrawerToggle drawerToggle;
 
@@ -151,33 +156,33 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_newsreader);
 
-        ButterKnife.inject(this);
+		ButterKnife.inject(this);
 
-        if (toolbar != null) {
-            setSupportActionBar(toolbar);
-        }
+		if (toolbar != null) {
+			setSupportActionBar(toolbar);
+		}
 
 		initAccountManager();
 
 		//Init config --> if nothing is configured start the login dialog.
-        SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
-        if(mPrefs.getString(SettingsActivity.EDT_OWNCLOUDROOTPATH_STRING, null) == null)
-        	StartLoginFragment(NewsReaderListActivity.this);
+		SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+		if (mPrefs.getString(SettingsActivity.EDT_OWNCLOUDROOTPATH_STRING, null) == null)
+			StartLoginFragment(NewsReaderListActivity.this);
 
 
 		Bundle args = new Bundle();
 		String userName = mPrefs.getString(SettingsActivity.EDT_USERNAME_STRING, null);
 		String url = mPrefs.getString(SettingsActivity.EDT_OWNCLOUDROOTPATH_STRING, null);
-		args.putString("accountName", String.format("%s\n%s",userName,url));
+		args.putString("accountName", String.format("%s\n%s", userName, url));
 		NewsReaderListFragment newsReaderListFragment = new NewsReaderListFragment();
 		newsReaderListFragment.setArguments(args);
-        // Insert the fragment by replacing any existing fragment
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        fragmentManager.beginTransaction()
-        				.replace(R.id.left_drawer, newsReaderListFragment)
-                   		.commit();
+		// Insert the fragment by replacing any existing fragment
+		FragmentManager fragmentManager = getSupportFragmentManager();
+		fragmentManager.beginTransaction()
+				.replace(R.id.left_drawer, newsReaderListFragment)
+				.commit();
 
-		if(drawerLayout != null) {
+		if (drawerLayout != null) {
 			drawerToggle = new ActionBarDrawerToggle(this, drawerLayout, toolbar, R.string.empty_view_content, R.string.empty_view_content) {
 				@Override
 				public void onDrawerClosed(View drawerView) {
@@ -196,52 +201,51 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 					syncState();
 
-                    showTapLogoToSyncShowcaseView();
+					showTapLogoToSyncShowcaseView();
 				}
 			};
 
 			drawerLayout.setDrawerListener(drawerToggle);
 
-            try {
-                // increase the size of the drag margin to prevent starting a star swipe when
-                // trying to open the drawer.
-                Field mDragger = drawerLayout.getClass().getDeclaredField(
-                        "mLeftDragger");
-                mDragger.setAccessible(true);
-                ViewDragHelper draggerObj = (ViewDragHelper) mDragger
-                        .get(drawerLayout);
+			try {
+				// increase the size of the drag margin to prevent starting a star swipe when
+				// trying to open the drawer.
+				Field mDragger = drawerLayout.getClass().getDeclaredField(
+						"mLeftDragger");
+				mDragger.setAccessible(true);
+				ViewDragHelper draggerObj = (ViewDragHelper) mDragger
+						.get(drawerLayout);
 
-                Field mEdgeSize = draggerObj.getClass().getDeclaredField(
-                        "mEdgeSize");
-                mEdgeSize.setAccessible(true);
-                int edge = mEdgeSize.getInt(draggerObj);
+				Field mEdgeSize = draggerObj.getClass().getDeclaredField(
+						"mEdgeSize");
+				mEdgeSize.setAccessible(true);
+				int edge = mEdgeSize.getInt(draggerObj);
 
-                mEdgeSize.setInt(draggerObj, edge * 3);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+				mEdgeSize.setInt(draggerObj, edge * 3);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
 		}
 		setSupportActionBar(toolbar);
 		getSupportActionBar().setDisplayShowHomeEnabled(true);
-		if(drawerToggle != null)
+		if (drawerToggle != null)
 			drawerToggle.syncState();
 
-        if(savedInstanceState == null)//When the app starts (no orientation change)
-        {
-        	StartDetailFragment(SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue(), true, null, true);
-        }
+		if (savedInstanceState == null)//When the app starts (no orientation change)
+		{
+			StartDetailFragment(SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue(), true, null, true);
+		}
 
-        //AppRater.app_launched(this);
-        //AppRater.rateNow(this);
+		//AppRater.app_launched(this);
+		//AppRater.rateNow(this);
 
 		UpdateButtonLayout();
 
-        bindUserInfoToUI();
-    }
+		bindUserInfoToUI();
+	}
 
 
-
-    private void showTapLogoToSyncShowcaseView() {
+	private void showTapLogoToSyncShowcaseView() {
 		NewsReaderListFragment nlf = getSlidingListFragment();
 		new MaterialShowcaseView.Builder(NewsReaderListActivity.this)
 				.setTarget(nlf.headerLogo)
@@ -250,13 +254,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				.setDelay(300) // optional but starting animations immediately in onCreate can make them choppy
 				.singleUse("LOGO_SYNC") // provide a unique ID used to ensure it is only shown once
 				.show();
-    }
+	}
 
-	View.OnClickListener mSnackbarListener = new View.OnClickListener()
-	{
+	View.OnClickListener mSnackbarListener = new View.OnClickListener() {
 		@Override
-		public void onClick(View view)
-		{
+		public void onClick(View view) {
 			//Toast.makeText(getActivity(), "button 1 pressed", 3000).show();
 
 			updateCurrentRssView();
@@ -264,13 +266,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	};
 
 
-
 	private static final String ID_FEED_STRING = "ID_FEED_STRING";
 	private static final String IS_FOLDER_BOOLEAN = "IS_FOLDER_BOOLEAN";
-	private static final String OPTIONAL_FOLDER_ID ="OPTIONAL_FOLDER_ID";
-	private static final String LIST_ADAPTER_TOTAL_COUNT ="LIST_ADAPTER_TOTAL_COUNT";
-    private static final String LIST_ADAPTER_PAGE_COUNT ="LIST_ADAPTER_PAGE_COUNT";
-
+	private static final String OPTIONAL_FOLDER_ID = "OPTIONAL_FOLDER_ID";
+	private static final String LIST_ADAPTER_TOTAL_COUNT = "LIST_ADAPTER_TOTAL_COUNT";
+	private static final String LIST_ADAPTER_PAGE_COUNT = "LIST_ADAPTER_PAGE_COUNT";
 
 
 	/* (non-Javadoc)
@@ -278,7 +278,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	 */
 	@Override
 	protected void onSaveInstanceState(Bundle outState) {
-        safeInstanceState(outState);
+		safeInstanceState(outState);
 		super.onSaveInstanceState(outState);
 	}
 
@@ -297,7 +297,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		}
 
 		//If the account is not in the Android Account Manager
-		if(!isAccountThere) {
+		if (!isAccountThere) {
 			//Then add the new account
 			Account account = new Account(getString(R.string.app_name), AccountGeneral.ACCOUNT_TYPE);
 			mAccountManager.addAccountExplicitly(account, "", new Bundle());
@@ -307,81 +307,81 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	}
 
 
-    private void safeInstanceState(Bundle outState) {
-        NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
-        if(ndf != null) {
-            outState.putLong(OPTIONAL_FOLDER_ID, ndf.getIdFeed() == null ? ndf.getIdFolder() : ndf.getIdFeed());
-            outState.putBoolean(IS_FOLDER_BOOLEAN, ndf.getIdFeed() == null);
-            outState.putLong(ID_FEED_STRING, ndf.getIdFeed() != null ? ndf.getIdFeed() : ndf.getIdFolder());
+	private void safeInstanceState(Bundle outState) {
+		NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
+		if (ndf != null) {
+			outState.putLong(OPTIONAL_FOLDER_ID, ndf.getIdFeed() == null ? ndf.getIdFolder() : ndf.getIdFeed());
+			outState.putBoolean(IS_FOLDER_BOOLEAN, ndf.getIdFeed() == null);
+			outState.putLong(ID_FEED_STRING, ndf.getIdFeed() != null ? ndf.getIdFeed() : ndf.getIdFolder());
 
-            NewsListRecyclerAdapter adapter = (NewsListRecyclerAdapter) ndf.getRecyclerView().getAdapter();
-			if(adapter != null) {
+			NewsListRecyclerAdapter adapter = (NewsListRecyclerAdapter) ndf.getRecyclerView().getAdapter();
+			if (adapter != null) {
 				outState.putInt(LIST_ADAPTER_TOTAL_COUNT, adapter.getTotalItemCount());
 				outState.putInt(LIST_ADAPTER_PAGE_COUNT, adapter.getCachedPages());
 			}
-        }
-    }
+		}
+	}
 
-    private void restoreInstanceState(Bundle savedInstanceState) {
-        if(savedInstanceState.containsKey(ID_FEED_STRING) &&
-                savedInstanceState.containsKey(IS_FOLDER_BOOLEAN) &&
-                savedInstanceState.containsKey(OPTIONAL_FOLDER_ID)) {
+	private void restoreInstanceState(Bundle savedInstanceState) {
+		if (savedInstanceState.containsKey(ID_FEED_STRING) &&
+				savedInstanceState.containsKey(IS_FOLDER_BOOLEAN) &&
+				savedInstanceState.containsKey(OPTIONAL_FOLDER_ID)) {
 
 
-            NewsListRecyclerAdapter adapter = new NewsListRecyclerAdapter(this, getNewsReaderDetailFragment().recyclerView, this);
+			NewsListRecyclerAdapter adapter = new NewsListRecyclerAdapter(this, getNewsReaderDetailFragment().recyclerView, this);
 
 			adapter.setTotalItemCount(savedInstanceState.getInt(LIST_ADAPTER_TOTAL_COUNT));
-            adapter.setCachedPages(savedInstanceState.getInt(LIST_ADAPTER_PAGE_COUNT));
+			adapter.setCachedPages(savedInstanceState.getInt(LIST_ADAPTER_PAGE_COUNT));
 
 			getNewsReaderDetailFragment()
 					.getRecyclerView()
 					.setAdapter(adapter);
 
-            StartDetailFragment(savedInstanceState.getLong(OPTIONAL_FOLDER_ID),
+			StartDetailFragment(savedInstanceState.getLong(OPTIONAL_FOLDER_ID),
 					savedInstanceState.getBoolean(IS_FOLDER_BOOLEAN),
 					savedInstanceState.getLong(ID_FEED_STRING),
 					false);
 		}
-    }
+	}
 
 	/* (non-Javadoc)
 	 * @see com.actionbarsherlock.app.SherlockFragmentActivity#onRestoreInstanceState(android.os.Bundle)
 	 */
 	@Override
 	protected void onRestoreInstanceState(@NonNull Bundle savedInstanceState) {
-        restoreInstanceState(savedInstanceState);
+		restoreInstanceState(savedInstanceState);
 		super.onRestoreInstanceState(savedInstanceState);
 	}
 
 	@Override
 	public void onPostCreate(Bundle savedInstanceState) {
 		super.onPostCreate(savedInstanceState);
-		if(drawerToggle != null)
+		if (drawerToggle != null)
 			drawerToggle.syncState();
 
-        boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
-        if (tabletSize) {
-            showTapLogoToSyncShowcaseView();
-        }
+		boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
+		if (tabletSize) {
+			showTapLogoToSyncShowcaseView();
+		}
 	}
 
 	@Override
 	public void onConfigurationChanged(Configuration newConfig) {
 		super.onConfigurationChanged(newConfig);
-		if(drawerToggle != null)
+		if (drawerToggle != null)
 			drawerToggle.onConfigurationChanged(newConfig);
 	}
 
 	public void reloadCountNumbersOfSlidingPaneAdapter() {
-        NewsReaderListFragment nlf = getSlidingListFragment();
-        if(nlf != null) {
-            nlf.ListViewNotifyDataSetChanged();
-        }
-    }
+		NewsReaderListFragment nlf = getSlidingListFragment();
+		if (nlf != null) {
+			nlf.ListViewNotifyDataSetChanged();
+		}
+	}
 
 	private void updateCurrentRssView() {
 		NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
-		if(ndf != null) {
+		if (ndf != null) {
 			//ndf.reloadAdapterFromScratch();
 			ndf.UpdateCurrentRssView(NewsReaderListActivity.this);
 		}
@@ -391,7 +391,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	protected void onStart() {
 		Intent serviceIntent = new Intent(this, OwnCloudSyncService.class);
 		mConnection = generateServiceConnection();
-		if(!isMyServiceRunning(OwnCloudSyncService.class)) {
+		if (!isMyServiceRunning(OwnCloudSyncService.class)) {
 			startService(serviceIntent);
 		}
 		bindService(serviceIntent, mConnection, Context.BIND_AUTO_CREATE);
@@ -400,7 +400,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 	@Override
 	protected void onStop() {
-		if(_ownCloudSyncService != null) {
+		if (_ownCloudSyncService != null) {
 			try {
 				_ownCloudSyncService.unregisterCallback(callback);
 			} catch (RemoteException e) {
@@ -423,11 +423,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 					//Start auto sync if enabled
 					SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(NewsReaderListActivity.this);
-					if(mPrefs.getBoolean(SettingsActivity.CB_SYNCONSTARTUP_STRING, false)) {
-                        if(!mSyncOnStartupPerformed) {
-                            startSync();
-                            mSyncOnStartupPerformed = true;
-                        }
+					if (mPrefs.getBoolean(SettingsActivity.CB_SYNCONSTARTUP_STRING, false)) {
+						if (!mSyncOnStartupPerformed) {
+							startSync();
+							mSyncOnStartupPerformed = true;
+						}
 
                         /*
                         long diffInMinutes = TimeUnit.MILLISECONDS.toMinutes(new Date().getTime() - mLastSyncDate.getTime());
@@ -435,10 +435,9 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
                             startSync();
                             mLastSyncDate = new Date();
                         }*/
-                    }
-                    UpdateButtonLayout();
-				}
-				catch (Exception e) {
+					}
+					UpdateButtonLayout();
+				} catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -447,8 +446,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			public void onServiceDisconnected(ComponentName name) {
 				try {
 					_ownCloudSyncService.unregisterCallback(callback);
-				}
-				catch (Exception e) {
+				} catch (Exception e) {
 					e.printStackTrace();
 				}
 			}
@@ -468,7 +466,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 		@Override
 		public void throwException(AidlException ex) throws RemoteException {
-			Toast.makeText(NewsReaderListActivity.this,ex.getmException().getLocalizedMessage(),Toast.LENGTH_LONG).show();
+			Toast.makeText(NewsReaderListActivity.this, ex.getmException().getLocalizedMessage(), Toast.LENGTH_LONG).show();
 
 			UpdateButtonLayoutWithHandler();
 		}
@@ -490,11 +488,10 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		}
 	};
 
-    /**
-     *
-     * @return true if new items count was greater than 0
-     */
-    private boolean syncFinishedHandler() {
+	/**
+	 * @return true if new items count was greater than 0
+	 */
+	private boolean syncFinishedHandler() {
 
 		ShowcaseConfig config = new ShowcaseConfig();
 		config.setDelay(300); // half second between each showcase view
@@ -506,39 +503,39 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 				"Swipe Left/Right to mark article as read", "GOT IT");
 		sequence.start();
 
-        NewsReaderListFragment newsReaderListFragment = getSlidingListFragment();
-        newsReaderListFragment.ReloadAdapter();
-        UpdateItemList();
-        UpdatePodcastView();
+		NewsReaderListFragment newsReaderListFragment = getSlidingListFragment();
+		newsReaderListFragment.ReloadAdapter();
+		UpdateItemList();
+		UpdatePodcastView();
 
-        AsyncTaskHelper.StartAsyncTask(new AsyncTaskGetUserInfo());
+		AsyncTaskHelper.StartAsyncTask(new AsyncTaskGetUserInfo());
 
-        SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(NewsReaderListActivity.this);
-        int newItemsCount = mPrefs.getInt(Constants.LAST_UPDATE_NEW_ITEMS_COUNT_STRING, 0);
+		SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(NewsReaderListActivity.this);
+		int newItemsCount = mPrefs.getInt(Constants.LAST_UPDATE_NEW_ITEMS_COUNT_STRING, 0);
 
-        if(newItemsCount > 0) {
-            int firstVisiblePosition = getNewsReaderDetailFragment().getFirstVisibleScrollPosition();
+		if (newItemsCount > 0) {
+			int firstVisiblePosition = getNewsReaderDetailFragment().getFirstVisibleScrollPosition();
 
-            //Only show the update snackbar if scrollposition is not top.
-            if(firstVisiblePosition == 0) {
-                updateCurrentRssView();
-            } else {
-                Snackbar snackbar = Snackbar.make(findViewById(R.id.coordinator_layout),
-                        getResources().getQuantityString(R.plurals.message_bar_new_articles_available, newItemsCount, newItemsCount),
-                        Snackbar.LENGTH_LONG);
-                snackbar.setAction(getString(R.string.message_bar_reload), mSnackbarListener);
-                snackbar.setActionTextColor(ContextCompat.getColor(this, R.color.accent_material_dark));
-                // Setting android:TextColor to #000 in the light theme results in black on black
-                // text on the Snackbar, set the text back to white,
-                // TODO: find a cleaner way to do this
-                TextView textView = (TextView) snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
-                textView.setTextColor(Color.WHITE);
-                snackbar.show();
-            }
-            return true;
-        }
-        return false;
-    }
+			//Only show the update snackbar if scrollposition is not top.
+			if (firstVisiblePosition == 0) {
+				updateCurrentRssView();
+			} else {
+				Snackbar snackbar = Snackbar.make(findViewById(R.id.coordinator_layout),
+						getResources().getQuantityString(R.plurals.message_bar_new_articles_available, newItemsCount, newItemsCount),
+						Snackbar.LENGTH_LONG);
+				snackbar.setAction(getString(R.string.message_bar_reload), mSnackbarListener);
+				snackbar.setActionTextColor(ContextCompat.getColor(this, R.color.accent_material_dark));
+				// Setting android:TextColor to #000 in the light theme results in black on black
+				// text on the Snackbar, set the text back to white,
+				// TODO: find a cleaner way to do this
+				TextView textView = (TextView) snackbar.getView().findViewById(android.support.design.R.id.snackbar_text);
+				textView.setTextColor(Color.WHITE);
+				snackbar.show();
+			}
+			return true;
+		}
+		return false;
+	}
 
 	@Override
 	protected void onResume() {
@@ -546,11 +543,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 		//reloadCountNumbersOfSlidingPaneAdapter();
 
-        //reload adapter - a sync could have been finished
-        NewsReaderListFragment newsReaderListFragment = getSlidingListFragment();
-        if(newsReaderListFragment != null) {
-            newsReaderListFragment.ReloadAdapter();
-        }
+		//reload adapter - a sync could have been finished
+		NewsReaderListFragment newsReaderListFragment = getSlidingListFragment();
+		if (newsReaderListFragment != null) {
+			newsReaderListFragment.ReloadAdapter();
+		}
 
 		invalidateOptionsMenu();
 
@@ -568,7 +565,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	 */
 	@Override
 	public void onTopItemClicked(long idFeed, boolean isFolder, Long optional_folder_id) {
-		if(drawerLayout != null)
+		if (drawerLayout != null)
 			drawerLayout.closeDrawer(GravityCompat.START);
 
 		StartDetailFragment(idFeed, isFolder, optional_folder_id, true);
@@ -576,7 +573,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 	@Override
 	public void onChildItemClicked(long idFeed, Long optional_folder_id) {
-		if(drawerLayout != null)
+		if (drawerLayout != null)
 			drawerLayout.closeDrawer(GravityCompat.START);
 
 		//StartDetailFragment(idSubscription, false, optional_folder_id);
@@ -585,18 +582,45 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 	@Override
 	public void onTopItemLongClicked(long idFeed, boolean isFolder, Long optional_folder_id) {
-		if(isFolder) {
-			//top-folder long-clicked
-		} else {
-			//top-item long-clicked
-		}
+		StartDialogFragment(idFeed, isFolder, optional_folder_id);
 	}
 
 	@Override
 	public void onChildItemLongClicked(long idFeed, Long optional_folder_id) {
-		//child-item long-clicked
-
+		StartDialogFragment(idFeed, false, optional_folder_id);
 	}
+
+
+	private void StartDialogFragment(long idFeed, Boolean isFolder, Long optional_folder_id) {
+
+		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+		Fragment prev = getSupportFragmentManager().findFragmentByTag("news_reader_list_dialog");
+		if (prev != null) {
+			ft.remove(prev);
+		}
+		ft.addToBackStack(null);
+
+		DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(getApplicationContext());
+
+		if (isFolder) {
+			//top-folder long-clicked
+			if(idFeed >= 0) {
+				String titel = dbConn.getFolderById(idFeed).getLabel();
+				System.out.println("*************************folderlongclicked: " +titel);
+			}
+
+		} else {
+			//top-item long-clicked
+			String titel = dbConn.getFeedById(idFeed).getFeedTitle();
+			String iconurl = dbConn.getFeedById(idFeed).getFaviconUrl();
+			String feedurl = dbConn.getFeedById(idFeed).getLink();
+
+			System.out.println("***********************: " + dbConn.getFeedById(idFeed).getLink());
+			DialogFragment fragment = NewsReaderListDialogFragment.newInstance(titel, iconurl, feedurl);
+			fragment.show(ft, "news_reader_list_dialog");
+		}
+	}
+
 
 	private NewsReaderDetailFragment StartDetailFragment(long id, Boolean folder, Long optional_folder_id, boolean updateListView)
 	{

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListActivity.java
@@ -139,13 +139,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 	//private Date mLastSyncDate = new Date(0);
 	private boolean mSyncOnStartupPerformed = false;
 
-	@InjectView(R.id.toolbar)
-	Toolbar toolbar;
+	@InjectView(R.id.toolbar) Toolbar toolbar;
 
 	private ServiceConnection mConnection = null;
 
-	@Optional
-	@InjectView(R.id.drawer_layout)
+	@Optional @InjectView(R.id.drawer_layout)
 	protected DrawerLayout drawerLayout;
 
 	private ActionBarDrawerToggle drawerToggle;
@@ -373,9 +371,6 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 			drawerToggle.onConfigurationChanged(newConfig);
 	}
 
-	public void switchToAllUnreadItems() {
-		StartDetailFragment(SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue(), true, null, true);
-	}
 	public void reloadCountNumbersOfSlidingPaneAdapter() {
 		NewsReaderListFragment nlf = getSlidingListFragment();
 		if (nlf != null) {
@@ -383,12 +378,16 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		}
 	}
 
-	public void updateCurrentRssView() {
+	protected void updateCurrentRssView() {
 		NewsReaderDetailFragment ndf = getNewsReaderDetailFragment();
 		if (ndf != null) {
 			//ndf.reloadAdapterFromScratch();
 			ndf.UpdateCurrentRssView(NewsReaderListActivity.this);
 		}
+	}
+
+	public void switchToAllUnreadItemsFolder() {
+		StartDetailFragment(SubscriptionExpandableListAdapter.SPECIAL_FOLDERS.ALL_UNREAD_ITEMS.getValue(), true, null, true);
 	}
 
 	@Override
@@ -580,7 +579,6 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 		if (drawerLayout != null)
 			drawerLayout.closeDrawer(GravityCompat.START);
 
-		//StartDetailFragment(idSubscription, false, optional_folder_id);
 		StartDetailFragment(idFeed, false, optional_folder_id, true);
 	}
 
@@ -596,28 +594,24 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
 
 
 	private void StartDialogFragment(long idFeed, Boolean isFolder, Long optional_folder_id) {
-
-		FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-		Fragment prev = getSupportFragmentManager().findFragmentByTag("news_reader_list_dialog");
-		if (prev != null) {
-			ft.remove(prev);
-		}
-		ft.addToBackStack(null);
-
 		DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(getApplicationContext());
 
 		if (isFolder) {
-			//top-folder long-clicked
 			if(idFeed >= 0) {
-				String titel = dbConn.getFolderById(idFeed).getLabel();
-				System.out.println("*************************folderlongclicked: " +titel);
+				//currently no actions for folders
+				//String titel = dbConn.getFolderById(idFeed).getLabel();
 			}
-
 		} else {
-			//top-item long-clicked
 			String titel = dbConn.getFeedById(idFeed).getFeedTitle();
 			String iconurl = dbConn.getFeedById(idFeed).getFaviconUrl();
 			String feedurl = dbConn.getFeedById(idFeed).getLink();
+
+			FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+			Fragment prev = getSupportFragmentManager().findFragmentByTag("news_reader_list_dialog");
+			if (prev != null) {
+				ft.remove(prev);
+			}
+			ft.addToBackStack(null);
 
 			NewsReaderListDialogFragment fragment = NewsReaderListDialogFragment.newInstance(idFeed, titel, iconurl, feedurl);
 			fragment.setActivity(this);
@@ -674,7 +668,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
     }
 
 
-    void startSync()
+    public void startSync()
     {
 		SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
 
@@ -889,11 +883,11 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
         }
     }
 
-	public /*private*/ NewsReaderListFragment getSlidingListFragment() {
+	protected NewsReaderListFragment getSlidingListFragment() {
 		return ((NewsReaderListFragment) getSupportFragmentManager().findFragmentById(R.id.left_drawer));
 	}
 
-	public NewsReaderDetailFragment getNewsReaderDetailFragment() {
+	protected NewsReaderDetailFragment getNewsReaderDetailFragment() {
 		 return (NewsReaderDetailFragment) getSupportFragmentManager().findFragmentById(R.id.content_frame);
 	}
 
@@ -913,7 +907,7 @@ public class NewsReaderListActivity extends PodcastFragmentActivity implements
     }
 
 
-	public /*private*/ void UpdateListView()
+	private void UpdateListView()
     {
         getNewsReaderDetailFragment().notifyDataSetChangedOnAdapter();
     }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
@@ -1,0 +1,152 @@
+package de.luhmer.owncloudnewsreader;
+
+import android.graphics.drawable.BitmapDrawable;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.nostra13.universalimageloader.cache.disc.DiskCache;
+import com.nostra13.universalimageloader.core.ImageLoader;
+
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
+
+
+/**
+ * Created by benson on 27/11/15.
+ */
+public class NewsReaderListDialogFragment extends DialogFragment{
+
+    static NewsReaderListDialogFragment newInstance(String dialogTitle, String iconurl, String feedurl) {
+        NewsReaderListDialogFragment f = new NewsReaderListDialogFragment();
+
+        Bundle args = new Bundle();
+        args.putString("title", dialogTitle);
+        args.putString("iconurl", iconurl);
+        args.putString("feedurl", feedurl);
+
+        f.setArguments(args);
+        return f;
+    }
+
+
+    private String mDialogTitle;
+    private String mDialogText;
+    private String mDialogIconUrl;
+    private URL mImageUrl;
+    private LinkedHashMap<String, MenuAction> mMenuItems;
+
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mDialogTitle = getArguments().getString("title");
+        mDialogIconUrl = getArguments().getString("iconurl");
+        mDialogText = getArguments().getString("feedurl");
+        mMenuItems = new LinkedHashMap<>();
+
+        mMenuItems.put("Rename feed"/*getString(R.string.action_img_download)*/, new MenuAction() {
+            @Override
+            public void execute() {
+                renameFeed();
+            }
+        });
+
+        mMenuItems.put("Remove feed"/*getString(R.string.action_img_download)*/, new MenuAction() {
+            @Override
+            public void execute() {
+                removeFeed();
+            }
+        });
+
+        int style = DialogFragment.STYLE_NO_TITLE;
+        int theme = ThemeChooser.isDarkTheme(getActivity())
+                ? R.style.Theme_Material_Dialog_Floating
+                : R.style.Theme_Material_Light_Dialog_Floating;
+        setStyle(style, theme);
+    }
+
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+
+        View v = inflater.inflate(R.layout.fragment_dialog_image, container, false);
+
+        TextView tvTitle = (TextView) v.findViewById(R.id.ic_menu_title);
+        TextView tvText = (TextView) v.findViewById(R.id.ic_menu_item_text);
+        ImageView imgTitle = (ImageView) v.findViewById(R.id.ic_menu_gallery);
+
+
+        tvTitle.setText(mDialogTitle);
+        tvText.setText(mDialogText);
+
+
+        ViewGroup.LayoutParams params=((View)imgTitle).getLayoutParams();
+        params.width=80;
+        params.height=80;
+        imgTitle.setLayoutParams(params);
+
+        if(mDialogIconUrl != null) {
+            DiskCache diskCache = ImageLoader.getInstance().getDiskCache();
+            File file = diskCache.get(mDialogIconUrl);
+            if (file != null) {
+                mDialogIconUrl = file.getAbsolutePath();
+                imgTitle.setImageDrawable(new BitmapDrawable(mDialogIconUrl));
+            } else {
+                imgTitle.setImageResource(R.drawable.default_feed_icon_light);
+            }
+        } else {
+            imgTitle.setImageResource(R.drawable.default_feed_icon_light);
+        }
+
+        ListView mListView = (ListView) v.findViewById(R.id.ic_menu_item_list);
+        List<String> menuItemsList = new ArrayList<>(mMenuItems.keySet());
+
+        final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<>(
+                getActivity(),
+                R.layout.fragment_dialog_listviewitem,
+                menuItemsList);
+
+        mListView.setAdapter(arrayAdapter);
+
+        mListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
+                String key = arrayAdapter.getItem(i);
+                MenuAction mAction = mMenuItems.get(key);
+                mAction.execute();
+            }
+        });
+
+        return v;
+    }
+
+
+
+
+    private void renameFeed() {
+        System.out.println("************** renameFeed");
+    }
+
+    private void removeFeed() {
+        System.out.println("************** removeFeed");
+    }
+
+    interface MenuAction {
+        void execute();
+    }
+}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
@@ -1,27 +1,38 @@
 package de.luhmer.owncloudnewsreader;
 
-import android.graphics.drawable.BitmapDrawable;
+import android.animation.AnimatorListenerAdapter;
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.ListView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
-import com.nostra13.universalimageloader.cache.disc.DiskCache;
-import com.nostra13.universalimageloader.core.ImageLoader;
-
-import java.io.File;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
+import de.luhmer.owncloudnewsreader.helper.FavIconHandler;
 import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
+import de.luhmer.owncloudnewsreader.reader.HttpJsonRequest;
+import de.luhmer.owncloudnewsreader.reader.owncloud.API;
+import de.luhmer.owncloudnewsreader.reader.owncloud.apiv2.APIv2;
 
 
 /**
@@ -29,10 +40,11 @@ import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
  */
 public class NewsReaderListDialogFragment extends DialogFragment{
 
-    static NewsReaderListDialogFragment newInstance(String dialogTitle, String iconurl, String feedurl) {
+    static NewsReaderListDialogFragment newInstance(long feedId, String dialogTitle, String iconurl, String feedurl) {
         NewsReaderListDialogFragment f = new NewsReaderListDialogFragment();
 
         Bundle args = new Bundle();
+        args.putLong("feedid", feedId);
         args.putString("title", dialogTitle);
         args.putString("iconurl", iconurl);
         args.putString("feedurl", feedurl);
@@ -42,40 +54,52 @@ public class NewsReaderListDialogFragment extends DialogFragment{
     }
 
 
+    private long mFeedId;
     private String mDialogTitle;
     private String mDialogText;
     private String mDialogIconUrl;
-    private URL mImageUrl;
+
+    private FavIconHandler favIconHandler;
+    private RemoveFeedTask mRemoveFeedTask = null;
+    private RenameFeedTask mRenameFeedTask = null;
     private LinkedHashMap<String, MenuAction> mMenuItems;
+
+    private NewsReaderListActivity parentActivity;
+
+    private RelativeLayout mRemoveFeedDialogView, mRenameFeedDialogView, mProgressView;
+    private Button mButtonRemoveConfirm, mButtonRemoveCancel, mButtonRenameConfirm, mButtonRenameCancel;
+    private ListView mListView;
+    private EditText mFeedName;
 
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
+        mFeedId = getArguments().getLong("feedid");
         mDialogTitle = getArguments().getString("title");
         mDialogIconUrl = getArguments().getString("iconurl");
         mDialogText = getArguments().getString("feedurl");
         mMenuItems = new LinkedHashMap<>();
 
-        mMenuItems.put("Rename feed"/*getString(R.string.action_img_download)*/, new MenuAction() {
+        mMenuItems.put(getString(R.string.action_feed_rename), new MenuAction() {
             @Override
             public void execute() {
-                renameFeed();
+                attemptRenameFeed(mFeedId, mDialogTitle);
             }
         });
 
-        mMenuItems.put("Remove feed"/*getString(R.string.action_img_download)*/, new MenuAction() {
+        mMenuItems.put(getString(R.string.action_feed_remove), new MenuAction() {
             @Override
             public void execute() {
-                removeFeed();
+                attemptRemoveFeed(mFeedId);
             }
         });
 
         int style = DialogFragment.STYLE_NO_TITLE;
         int theme = ThemeChooser.isDarkTheme(getActivity())
-                ? R.style.Theme_Material_Dialog_Floating
-                : R.style.Theme_Material_Light_Dialog_Floating;
+                ? R.style.FloatingDialog
+                : R.style.FloatingDialogLight;
         setStyle(style, theme);
     }
 
@@ -84,36 +108,39 @@ public class NewsReaderListDialogFragment extends DialogFragment{
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
-        View v = inflater.inflate(R.layout.fragment_dialog_image, container, false);
+        View v = inflater.inflate(R.layout.fragment_dialog_feedoptions, container, false);
 
         TextView tvTitle = (TextView) v.findViewById(R.id.ic_menu_title);
         TextView tvText = (TextView) v.findViewById(R.id.ic_menu_item_text);
-        ImageView imgTitle = (ImageView) v.findViewById(R.id.ic_menu_gallery);
+        ImageView imgTitle = (ImageView) v.findViewById(R.id.ic_menu_feedicon);
 
+        mRemoveFeedDialogView = (RelativeLayout) v.findViewById(R.id.remove_feed_dialog);
+        mRenameFeedDialogView = (RelativeLayout) v.findViewById(R.id.rename_feed_dialog);
+        mProgressView = (RelativeLayout) v.findViewById(R.id.progressView);
+        mButtonRemoveConfirm = (Button) v.findViewById(R.id.button_remove_confirm);
+        mButtonRemoveCancel = (Button) v.findViewById(R.id.button_remove_cancel);
+        mButtonRenameConfirm = (Button) v.findViewById(R.id.button_rename_confirm);
+        mButtonRenameCancel = (Button) v.findViewById(R.id.button_rename_cancel);
+        mFeedName = (EditText) v.findViewById(R.id.renamefeed_feedname);
 
         tvTitle.setText(mDialogTitle);
         tvText.setText(mDialogText);
 
-
-        ViewGroup.LayoutParams params=((View)imgTitle).getLayoutParams();
-        params.width=80;
-        params.height=80;
-        imgTitle.setLayoutParams(params);
-
-        if(mDialogIconUrl != null) {
-            DiskCache diskCache = ImageLoader.getInstance().getDiskCache();
-            File file = diskCache.get(mDialogIconUrl);
-            if (file != null) {
-                mDialogIconUrl = file.getAbsolutePath();
-                imgTitle.setImageDrawable(new BitmapDrawable(mDialogIconUrl));
-            } else {
-                imgTitle.setImageResource(R.drawable.default_feed_icon_light);
+        tvText.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(mDialogText != null) {
+                    Intent i = new Intent(Intent.ACTION_VIEW);
+                    i.setData(Uri.parse(mDialogText));
+                    startActivity(i);
+                }
             }
-        } else {
-            imgTitle.setImageResource(R.drawable.default_feed_icon_light);
-        }
+        });
 
-        ListView mListView = (ListView) v.findViewById(R.id.ic_menu_item_list);
+        favIconHandler = new FavIconHandler(getContext());
+        favIconHandler.loadFavIconForFeed(mDialogIconUrl, imgTitle);
+
+        mListView = (ListView) v.findViewById(R.id.xx_menu_item_list);
         List<String> menuItemsList = new ArrayList<>(mMenuItems.keySet());
 
         final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<>(
@@ -132,21 +159,212 @@ public class NewsReaderListDialogFragment extends DialogFragment{
             }
         });
 
+
         return v;
     }
 
 
+    public void setActivity(Activity parentActivity) {
+        this.parentActivity =  (NewsReaderListActivity)parentActivity;
 
-
-    private void renameFeed() {
-        System.out.println("************** renameFeed");
     }
 
-    private void removeFeed() {
-        System.out.println("************** removeFeed");
+
+    public void showProgress(final boolean show) {
+        int shortAnimTime = getResources().getInteger(android.R.integer.config_shortAnimTime);
+
+        mRenameFeedDialogView.setVisibility(show ? View.GONE : View.VISIBLE);
+        mRemoveFeedDialogView.setVisibility(show ? View.GONE : View.VISIBLE);
+
+        mProgressView.setVisibility(show ? View.VISIBLE : View.GONE);
+        mProgressView.animate().setDuration(shortAnimTime).alpha(
+                show ? 1 : 0).setListener(new AnimatorListenerAdapter() {
+        });
     }
+
+
+    private void attemptRenameFeed(final long feedId, final String feedName) {
+
+        mFeedName.setText(feedName);
+        mButtonRenameConfirm.setEnabled(false);
+
+        mListView.setVisibility(View.GONE);
+        mRenameFeedDialogView.setVisibility(View.VISIBLE);
+
+        mFeedName.addTextChangedListener(new TextWatcher() {
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start,
+                                          int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start,
+                                      int before, int count) {
+                if (s.toString().equals(feedName) || s.length() == 0) {
+                    mButtonRenameConfirm.setEnabled(false);
+                } else {
+                    mButtonRenameConfirm.setEnabled(true);
+                }
+            }
+        });
+
+
+        mButtonRenameCancel.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                dismiss();
+            }
+        });
+
+        mButtonRenameConfirm.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                showProgress(true);
+                setCancelable(false);
+                getDialog().setCanceledOnTouchOutside(false);
+                mRenameFeedTask = new RenameFeedTask(feedId, mFeedName.getText().toString() ); //TODO needs testing!
+                mRenameFeedTask.execute((Void) null);
+            }
+        });
+    }
+
+    private void attemptRemoveFeed(final long feedId) {
+
+        mListView.setVisibility(View.GONE);
+        mRemoveFeedDialogView.setVisibility(View.VISIBLE);
+
+        mButtonRemoveCancel.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                dismiss();
+            }
+        });
+
+        mButtonRemoveConfirm.setOnClickListener(new View.OnClickListener() {
+            public void onClick(View v) {
+                showProgress(true);
+                setCancelable(false);
+                getDialog().setCanceledOnTouchOutside(false);
+                mRemoveFeedTask = new RemoveFeedTask(feedId); //TODO needs testing!
+                mRemoveFeedTask.execute((Void) null);
+            }
+        });
+    }
+
 
     interface MenuAction {
         void execute();
+    }
+
+
+
+    public class RemoveFeedTask extends AsyncTask<Void, Void, Boolean> {
+
+        private final long mFeedId;
+
+        RemoveFeedTask(long feedId) {
+            this.mFeedId = feedId;
+        }
+
+        @Override
+        protected Boolean doInBackground(Void... params) {
+            API api = new APIv2(HttpJsonRequest.getInstance().getRootUrl());
+
+            try {
+                int status = HttpJsonRequest.getInstance().performRemoveFeedRequest(api.getFeedUrl(),
+                        mFeedId);
+                if(status == 200) {
+                    return true;
+                }
+
+                Log.d("NewFeedActivity", "Status: " + status);
+            } catch(Exception ex) {
+                ex.printStackTrace();
+            }
+            return false;
+        }
+
+        @Override
+        protected void onPostExecute(final Boolean success) {
+            mRemoveFeedTask = null;
+
+            if (success) {
+                DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(getContext());
+                dbConn.removeFeedById(mFeedId);
+
+                Long currentFeedId = parentActivity.getNewsReaderDetailFragment().getIdFeed();
+                if(currentFeedId != null && currentFeedId == mFeedId) {
+                    parentActivity.switchToAllUnreadItems();
+                }
+                parentActivity.getSlidingListFragment().ReloadAdapter();
+                parentActivity.updateCurrentRssView();
+
+                //parentActivity.UpdateItemList();
+                //parentActivity.UpdateListView();
+                //parentActivity.getSlidingListFragment().ListViewNotifyDataSetChanged();
+                //parentActivity.startSync();
+            } else {
+                Toast.makeText(getContext().getApplicationContext(), getString(R.string.login_dialog_text_something_went_wrong), Toast.LENGTH_LONG).show();
+            }
+            dismiss();
+        }
+
+        @Override
+        protected void onCancelled() {
+            mRemoveFeedTask = null;
+            dismiss();
+        }
+    }
+
+
+    public class RenameFeedTask extends AsyncTask<Void, Void, Boolean> {
+
+        private final long mFeedId;
+        private final String mFeedName;
+
+        RenameFeedTask(long feedId, String newName) {
+            mFeedId = feedId;
+            mFeedName = newName;
+        }
+
+        @Override
+        protected Boolean doInBackground(Void... params) {
+            API api = new APIv2(HttpJsonRequest.getInstance().getRootUrl());
+
+            try {
+                int status = HttpJsonRequest.getInstance().performRenameFeedRequest(api.getFeedUrl(),
+                        mFeedId, mFeedName);
+                if(status == 200) {
+                    return true;
+                }
+                Log.d("NewFeedActivity", "Status: " + status);
+            } catch(Exception ex) {
+                ex.printStackTrace();
+            }
+            return false;
+        }
+
+        @Override
+        protected void onPostExecute(final Boolean success) {
+            mRenameFeedTask = null;
+
+            if (success) {
+                DatabaseConnectionOrm dbConn = new DatabaseConnectionOrm(getContext());
+                dbConn.renameFeedById(mFeedId, mFeedName);
+
+                parentActivity.getSlidingListFragment().ReloadAdapter();
+                //parentActivity.updateCurrentRssView();
+                parentActivity.startSync();
+            } else {
+                Toast.makeText(getContext().getApplicationContext(), getString(R.string.login_dialog_text_something_went_wrong), Toast.LENGTH_LONG).show();
+            }
+            dismiss();
+        }
+
+        @Override
+        protected void onCancelled() {
+            mRenameFeedTask = null;
+            dismiss();
+        }
     }
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -41,8 +41,10 @@ import butterknife.ButterKnife;
 import butterknife.InjectView;
 import de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter;
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
+import de.luhmer.owncloudnewsreader.database.model.Feed;
 import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import de.luhmer.owncloudnewsreader.interfaces.ExpListTextClicked;
+import de.luhmer.owncloudnewsreader.model.ConcreteFeedItem;
 import de.luhmer.owncloudnewsreader.model.FolderSubscribtionItem;
 
 /**
@@ -200,7 +202,6 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 				int groupPosition, int childPosition, long id) {
 
 			long idItem = lvAdapter.getChildId(groupPosition, childPosition);
-
 			Long optional_id_folder = null;
 			FolderSubscribtionItem groupItem = (FolderSubscribtionItem) lvAdapter.getGroup(groupPosition);
 			if(groupItem != null)
@@ -221,17 +222,15 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 				int groupPosition = ExpandableListView.getPackedPositionGroup(id);
 				int childPosition = ExpandableListView.getPackedPositionChild(id);
 
-				long idItem = lvAdapter.getChildId(groupPosition, childPosition);
-
 				Long optional_id_folder = null;
 				FolderSubscribtionItem groupItem = (FolderSubscribtionItem) lvAdapter.getGroup(groupPosition);
 				if(groupItem != null)
 					optional_id_folder = groupItem.id_database;
 
-				mCallbacks.onChildItemLongClicked(idItem, optional_id_folder);
+				mCallbacks.onChildItemLongClicked(childPosition, optional_id_folder);
 			}
 
-			return false;
+			return true;
 		}
 	};
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -218,16 +218,8 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 		@Override
 		public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
 			if (ExpandableListView.getPackedPositionType(id) == ExpandableListView.PACKED_POSITION_TYPE_CHILD) {
-
-				int groupPosition = ExpandableListView.getPackedPositionGroup(id);
 				int childPosition = ExpandableListView.getPackedPositionChild(id);
-
-				Long optional_id_folder = null;
-				FolderSubscribtionItem groupItem = (FolderSubscribtionItem) lvAdapter.getGroup(groupPosition);
-				if(groupItem != null)
-					optional_id_folder = groupItem.id_database;
-
-				mCallbacks.onChildItemLongClicked(childPosition, optional_id_folder);
+				mCallbacks.onChildItemLongClicked(childPosition, null);
 			}
 
 			return true;

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -31,6 +31,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnCreateContextMenuListener;
 import android.view.ViewGroup;
+import android.widget.AdapterView;
 import android.widget.ExpandableListView;
 import android.widget.ExpandableListView.OnChildClickListener;
 import android.widget.ImageView;
@@ -95,6 +96,8 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 		 */
 		void onChildItemClicked(long idFeed, Long optional_folder_id);
 		void onTopItemClicked(long idFeed, boolean isFolder, Long optional_folder_id);
+		void onChildItemLongClicked(long idFeed, Long optional_folder_id);
+		void onTopItemLongClicked(long idFeed, boolean isFolder, Long optional_folder_id);
 	}
 
 
@@ -131,8 +134,10 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 		eListView.setGroupIndicator(null);
 
 		eListView.setOnChildClickListener(onChildClickListener);
+		eListView.setOnItemLongClickListener(onItemLongClickListener);
 
 		eListView.setClickable(true);
+		eListView.setLongClickable(true);
 		eListView.setAdapter(lvAdapter);
 
 		SharedPreferences mPrefs = PreferenceManager.getDefaultSharedPreferences(getActivity());
@@ -178,9 +183,15 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 
 		@Override
 		public void onTextClicked(long idFeed, boolean isFolder, Long optional_folder_id) {
-            mCallbacks.onTopItemClicked(idFeed, isFolder, optional_folder_id);
+			mCallbacks.onTopItemClicked(idFeed, isFolder, optional_folder_id);
 		}
-    };
+
+		@Override
+		public void onTextLongClicked(long idFeed, boolean isFolder, Long optional_folder_id) {
+			mCallbacks.onTopItemLongClicked(idFeed, isFolder, optional_folder_id);
+		}
+
+	};
 
 	OnChildClickListener onChildClickListener = new OnChildClickListener() {
 
@@ -200,4 +211,28 @@ public class NewsReaderListFragment extends Fragment implements OnCreateContextM
 			return false;
 		}
 	};
+
+	AdapterView.OnItemLongClickListener onItemLongClickListener = new AdapterView.OnItemLongClickListener() {
+
+		@Override
+		public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+			if (ExpandableListView.getPackedPositionType(id) == ExpandableListView.PACKED_POSITION_TYPE_CHILD) {
+
+				int groupPosition = ExpandableListView.getPackedPositionGroup(id);
+				int childPosition = ExpandableListView.getPackedPositionChild(id);
+
+				long idItem = lvAdapter.getChildId(groupPosition, childPosition);
+
+				Long optional_id_folder = null;
+				FolderSubscribtionItem groupItem = (FolderSubscribtionItem) lvAdapter.getGroup(groupPosition);
+				if(groupItem != null)
+					optional_id_folder = groupItem.id_database;
+
+				mCallbacks.onChildItemLongClicked(idItem, optional_id_folder);
+			}
+
+			return false;
+		}
+	};
+
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListFragment.java
@@ -41,10 +41,8 @@ import butterknife.ButterKnife;
 import butterknife.InjectView;
 import de.luhmer.owncloudnewsreader.ListView.SubscriptionExpandableListAdapter;
 import de.luhmer.owncloudnewsreader.database.DatabaseConnectionOrm;
-import de.luhmer.owncloudnewsreader.database.model.Feed;
 import de.luhmer.owncloudnewsreader.helper.ThemeChooser;
 import de.luhmer.owncloudnewsreader.interfaces.ExpListTextClicked;
-import de.luhmer.owncloudnewsreader.model.ConcreteFeedItem;
 import de.luhmer.owncloudnewsreader.model.FolderSubscribtionItem;
 
 /**

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -330,10 +330,26 @@ public class DatabaseConnectionOrm {
 
     public void removeFeedById(long feedId) {
         daoSession.getFeedDao().deleteByKey(feedId);
+
+        List<RssItem> list = daoSession.getRssItemDao().queryBuilder().where(RssItemDao.Properties.FeedId.eq(feedId)).list();
+        for (RssItem rssItem : list) {
+            //if(!rssItem.getStarred() && !rssItem.getStarred_temp()) {
+                daoSession.getRssItemDao().delete(rssItem);
+            //}
+        }
     }
 
-
-
+    public void renameFeedById(long feedId, String newTitle) {
+        Feed feed = daoSession.getFeedDao().queryBuilder().where(FeedDao.Properties.Id.eq(feedId)).unique();
+        feed.setFeedTitle(newTitle);
+        /*
+        List<RssItem> list = daoSession.getRssItemDao().queryBuilder().where(RssItemDao.Properties.FeedId.eq(feedId)).list();
+        for (RssItem rssItem : list) {
+            rssItem.setFeed(feed);
+        }
+        */
+        daoSession.getFeedDao().update(feed);
+    }
 
     public SparseArray<String> getUrlsToFavIcons() {
         SparseArray<String> favIconUrls = new SparseArray<>();

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/database/DatabaseConnectionOrm.java
@@ -327,27 +327,18 @@ public class DatabaseConnectionOrm {
         return feeds.size() > 0;
     }
 
-
     public void removeFeedById(long feedId) {
         daoSession.getFeedDao().deleteByKey(feedId);
 
         List<RssItem> list = daoSession.getRssItemDao().queryBuilder().where(RssItemDao.Properties.FeedId.eq(feedId)).list();
         for (RssItem rssItem : list) {
-            //if(!rssItem.getStarred() && !rssItem.getStarred_temp()) {
-                daoSession.getRssItemDao().delete(rssItem);
-            //}
+            daoSession.getRssItemDao().delete(rssItem);
         }
     }
 
     public void renameFeedById(long feedId, String newTitle) {
         Feed feed = daoSession.getFeedDao().queryBuilder().where(FeedDao.Properties.Id.eq(feedId)).unique();
         feed.setFeedTitle(newTitle);
-        /*
-        List<RssItem> list = daoSession.getRssItemDao().queryBuilder().where(RssItemDao.Properties.FeedId.eq(feedId)).list();
-        for (RssItem rssItem : list) {
-            rssItem.setFeed(feed);
-        }
-        */
         daoSession.getFeedDao().update(feed);
     }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/interfaces/ExpListTextClicked.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/interfaces/ExpListTextClicked.java
@@ -23,4 +23,5 @@ package de.luhmer.owncloudnewsreader.interfaces;
 
 public interface ExpListTextClicked {
 	void onTextClicked(long idFeed, boolean isFolder, Long optional_folder_id);
+	void onTextLongClicked(long idFeed, boolean isFolder, Long optional_folder_id);
 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/HttpJsonRequest.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/HttpJsonRequest.java
@@ -189,7 +189,6 @@ public class HttpJsonRequest {
         return response.code();
     }
 
-
     public int performRemoveFeedRequest(HttpUrl url, long feedId) throws Exception {
         HttpUrl feedUrl = url.newBuilder()
                 .addPathSegment(String.valueOf(feedId))
@@ -204,7 +203,6 @@ public class HttpJsonRequest {
 
         return response.code();
     }
-
 
     public int performRenameFeedRequest(HttpUrl url, long feedId, String newFeedName) throws Exception {
         HttpUrl feedUrl = url.newBuilder()
@@ -221,8 +219,6 @@ public class HttpJsonRequest {
 
         return response.code();
     }
-
-
 
 	public int performTagChangeRequest(HttpUrl url, String content) throws Exception
 	{

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/HttpJsonRequest.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/HttpJsonRequest.java
@@ -34,6 +34,8 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 
+import org.json.JSONObject;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyManagementException;
@@ -186,6 +188,41 @@ public class HttpJsonRequest {
 
         return response.code();
     }
+
+
+    public int performRemoveFeedRequest(HttpUrl url, long feedId) throws Exception {
+        HttpUrl feedUrl = url.newBuilder()
+                .addPathSegment(String.valueOf(feedId))
+                .build();
+
+        Request request = new Request.Builder()
+                .url(feedUrl)
+                .delete()
+                .build();
+
+        Response response = client.newCall(request).execute();
+
+        return response.code();
+    }
+
+
+    public int performRenameFeedRequest(HttpUrl url, long feedId, String newFeedName) throws Exception {
+        HttpUrl feedUrl = url.newBuilder()
+                .addPathSegment(String.valueOf(feedId))
+                .addPathSegment("rename")
+                .build();
+
+        Request request = new Request.Builder()
+                .url(feedUrl)
+                .put(RequestBody.create(JSON, new JSONObject().put("feedTitle", newFeedName).toString()))
+                .build();
+
+        Response response = client.newCall(request).execute();
+
+        return response.code();
+    }
+
+
 
 	public int performTagChangeRequest(HttpUrl url, String content) throws Exception
 	{

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/InsertIntoDatabase.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/InsertIntoDatabase.java
@@ -79,8 +79,12 @@ public class InsertIntoDatabase {
                 boolean found = false;
                 for(int i = 0; i < newFeeds.size(); i++)
                 {
-                    if(newFeeds.get(i).getFeedTitle().equals(feed.getFeedTitle()))
+                    if(newFeeds.get(i).getLink().equals(feed.getLink()))
                     {
+                        if(!newFeeds.get(i).getFeedTitle().equals(feed.getFeedTitle()))
+                        {
+                            feed.setFeedTitle(newFeeds.get(i).getFeedTitle());
+                        }
                         //Set the avg color after sync again.
                         feed.setAvgColour(oldFeeds.get(i).getAvgColour());
                         dbConn.updateFeed(feed);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/owncloud/InsertFeedIntoDatabase.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/owncloud/InsertFeedIntoDatabase.java
@@ -50,8 +50,8 @@ public class InsertFeedIntoDatabase implements IHandleJsonObject{
         feed.setFeedTitle(e.optString("title"));
         feed.setFolderId(e.optLong("folderId"));
         feed.setFaviconUrl(faviconLink);
-		//feed.setLink(e.optString("link"));
 		feed.setLink(e.optString("url"));
+		//feed.setLink(e.optString("link"));
 
         return feed;
 	}

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/owncloud/InsertFeedIntoDatabase.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/reader/owncloud/InsertFeedIntoDatabase.java
@@ -50,6 +50,8 @@ public class InsertFeedIntoDatabase implements IHandleJsonObject{
         feed.setFeedTitle(e.optString("title"));
         feed.setFolderId(e.optLong("folderId"));
         feed.setFaviconUrl(faviconLink);
+		//feed.setLink(e.optString("link"));
+		feed.setLink(e.optString("url"));
 
         return feed;
 	}

--- a/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    android:paddingBottom="6dp"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin">
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="6dp"
+        android:layout_marginBottom="4dp"
+        android:id="@+id/title_wrapper">
+
+        <ImageView
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center_vertical"
+            android:id="@+id/ic_menu_feedicon"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="5dp"
+            android:id="@+id/ic_menu_title"
+            tools:text="Sample1"
+            android:layout_centerVertical="true"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:layout_toRightOf="@+id/ic_menu_feedicon"
+            android:layout_toEndOf="@+id/ic_menu_feedicon"/>
+
+    </RelativeLayout>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingLeft="6dp"
+        android:id="@+id/ic_menu_item_text"
+        tools:text="Sample1"
+        android:textSize="14sp"
+        android:layout_marginTop="2dp"
+        android:layout_below="@+id/title_wrapper"
+        android:textStyle="normal"/>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginLeft="0dp"
+        android:layout_marginRight="0dp"
+        android:background="#c8ababab"
+        android:layout_below="@+id/ic_menu_item_text"/>
+
+    <ListView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="13dp"
+        android:divider="@null"
+        android:id="@+id/xx_menu_item_list"
+        android:layout_below="@+id/ic_menu_item_text">
+    </ListView>
+
+    <RelativeLayout
+        android:id="@+id/remove_feed_dialog"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ic_menu_item_text"
+        android:layout_marginTop="13dp"
+        android:visibility="gone">
+        <TextView
+            android:layout_marginTop="13dp"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:paddingRight="6dp"
+            android:paddingLeft="6dp"
+            android:textSize="18sp"
+            android:id="@+id/textView"
+            android:layout_alignParentEnd="false"
+            android:layout_alignParentStart="true"
+            android:text="Do you really want to remove this Feed?
+            This cannot be undone!"
+            android:layout_marginBottom="13dp"></TextView>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/textView"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp">
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_height="wrap_content"
+                android:text="Cancel"
+                android:id="@+id/button_remove_cancel"
+                android:layout_weight="1"
+                android:layout_width="0dp"
+                android:layout_marginLeft="0dp" />
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_height="wrap_content"
+                android:text="Remove"
+                android:id="@+id/button_remove_confirm"
+                android:layout_toEndOf="@id/button_remove_confirm"
+                android:layout_weight="1"
+                android:layout_width="0dp"
+                android:layout_marginRight="0dp" />
+        </LinearLayout>
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/rename_feed_dialog"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ic_menu_item_text"
+        android:layout_marginTop="13dp"
+        android:visibility="gone">
+        <EditText
+            android:layout_marginTop="13dp"
+            android:paddingRight="6dp"
+            android:paddingLeft="6dp"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/renamefeed_feedname"
+            android:layout_alignParentEnd="false"
+            android:layout_alignParentStart="true"
+            android:textSize="18sp"
+            android:text="Do you really want to remove this Feed? This cannot be undone!"
+            android:layout_marginBottom="13dp"
+            android:singleLine="true"
+            android:lines="1"
+            android:imeOptions="actionDone"
+            android:inputType="textVisiblePassword"></EditText>
+
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/renamefeed_feedname"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginLeft="0dp"
+            android:layout_marginRight="0dp">
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_height="wrap_content"
+                android:text="Cancel"
+                android:id="@+id/button_rename_cancel"
+                android:layout_weight="1"
+                android:layout_width="0dp"
+                android:layout_marginLeft="0dp" />
+
+            <Button
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_height="wrap_content"
+                android:text="Rename"
+                android:id="@+id/button_rename_confirm"
+                android:layout_toEndOf="@id/button_rename_cancel"
+                android:layout_weight="1"
+                android:layout_width="0dp"
+                android:layout_marginRight="0dp" />
+        </LinearLayout>
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/progressView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/ic_menu_item_text"
+        android:layout_marginTop="13dp"
+        android:visibility="gone">
+        <ProgressBar
+            android:id="@+id/alter_feedSource_progress"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="12dp"
+            android:layout_marginTop="12dp"/>
+    </RelativeLayout>
+
+</RelativeLayout>

--- a/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
+++ b/News-Android-App/src/main/res/layout/fragment_dialog_feedoptions.xml
@@ -1,121 +1,119 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!--  -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingTop="@dimen/activity_vertical_margin"
+    android:orientation="vertical"
     android:paddingBottom="6dp"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingLeft="@dimen/activity_horizontal_margin">
+    android:paddingTop="@dimen/activity_vertical_margin">
 
     <RelativeLayout
+        android:id="@+id/title_wrapper"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="6dp"
         android:layout_marginBottom="4dp"
-        android:id="@+id/title_wrapper">
+        android:padding="6dp">
 
         <ImageView
+            android:id="@+id/ic_menu_feedicon"
             android:layout_width="24dp"
             android:layout_height="24dp"
-            android:layout_gravity="center_vertical"
-            android:id="@+id/ic_menu_feedicon"/>
+            android:layout_gravity="center_vertical"/>
 
         <TextView
+            android:id="@+id/tv_menu_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="5dp"
-            android:id="@+id/ic_menu_title"
-            tools:text="Sample1"
             android:layout_centerVertical="true"
+            android:layout_marginStart="5dp"
+            android:layout_toEndOf="@+id/ic_menu_feedicon"
+            android:layout_toRightOf="@+id/ic_menu_feedicon"
             android:textSize="16sp"
             android:textStyle="bold"
-            android:layout_toRightOf="@+id/ic_menu_feedicon"
-            android:layout_toEndOf="@+id/ic_menu_feedicon"/>
+            tools:text="NameOfFeed"/>
 
     </RelativeLayout>
 
     <TextView
+        android:id="@+id/tv_menu_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingLeft="6dp"
-        android:id="@+id/ic_menu_item_text"
-        tools:text="Sample1"
-        android:textSize="14sp"
-        android:layout_marginTop="2dp"
         android:layout_below="@+id/title_wrapper"
-        android:textStyle="normal"/>
+        android:layout_marginTop="2dp"
+        android:paddingEnd="6dp"
+        android:paddingStart="6dp"
+        android:textSize="14sp"
+        android:textStyle="normal"
+        tools:text="UrlOfFeed"/>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="1dp"
-        android:layout_marginTop="12dp"
+        android:layout_below="@+id/tv_menu_text"
         android:layout_marginLeft="0dp"
         android:layout_marginRight="0dp"
-        android:background="#c8ababab"
-        android:layout_below="@+id/ic_menu_item_text"/>
+        android:layout_marginTop="12dp"
+        android:background="#c8ababab"/>
 
     <ListView
+        android:id="@+id/lv_menu_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_below="@+id/tv_menu_text"
         android:layout_marginTop="13dp"
-        android:divider="@null"
-        android:id="@+id/xx_menu_item_list"
-        android:layout_below="@+id/ic_menu_item_text">
-    </ListView>
+        android:divider="@null"/>
 
     <RelativeLayout
         android:id="@+id/remove_feed_dialog"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/ic_menu_item_text"
+        android:layout_below="@+id/tv_menu_text"
         android:layout_marginTop="13dp"
         android:visibility="gone">
         <TextView
-            android:layout_marginTop="13dp"
+            android:id="@+id/tv_detail_text"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:paddingRight="6dp"
-            android:paddingLeft="6dp"
-            android:textSize="18sp"
-            android:id="@+id/textView"
             android:layout_alignParentEnd="false"
             android:layout_alignParentStart="true"
-            android:text="Do you really want to remove this Feed?
-            This cannot be undone!"
-            android:layout_marginBottom="13dp"></TextView>
+            android:layout_marginBottom="13dp"
+            android:layout_marginTop="13dp"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp"
+            android:text="@string/confirm_feed_remove"
+            android:textSize="18sp" />
 
         <LinearLayout
-            android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/textView"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
+            android:layout_below="@+id/tv_detail_text"
             android:layout_marginLeft="0dp"
-            android:layout_marginRight="0dp">
+            android:layout_marginRight="0dp"
+            android:orientation="horizontal">
 
             <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_height="wrap_content"
-                android:text="Cancel"
                 android:id="@+id/button_remove_cancel"
-                android:layout_weight="1"
+                style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="0dp"
-                android:layout_marginLeft="0dp" />
+                android:layout_height="wrap_content"
+                android:layout_marginStart="0dp"
+                android:layout_weight="1"
+                android:text="@android:string/cancel" />
 
             <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_height="wrap_content"
-                android:text="Remove"
                 android:id="@+id/button_remove_confirm"
-                android:layout_toEndOf="@id/button_remove_confirm"
-                android:layout_weight="1"
+                style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="0dp"
-                android:layout_marginRight="0dp" />
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="0dp"
+                android:layout_weight="1"
+                android:text="@string/feed_remove_button" />
         </LinearLayout>
 
     </RelativeLayout>
@@ -124,54 +122,52 @@
         android:id="@+id/rename_feed_dialog"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/ic_menu_item_text"
+        android:layout_below="@+id/tv_menu_text"
         android:layout_marginTop="13dp"
         android:visibility="gone">
         <EditText
-            android:layout_marginTop="13dp"
-            android:paddingRight="6dp"
-            android:paddingLeft="6dp"
+            android:id="@+id/renamefeed_feedname"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/renamefeed_feedname"
             android:layout_alignParentEnd="false"
             android:layout_alignParentStart="true"
-            android:textSize="18sp"
-            android:text="Do you really want to remove this Feed? This cannot be undone!"
             android:layout_marginBottom="13dp"
-            android:singleLine="true"
-            android:lines="1"
+            android:layout_marginTop="13dp"
             android:imeOptions="actionDone"
-            android:inputType="textVisiblePassword"></EditText>
+            android:inputType="textVisiblePassword"
+            android:lines="1"
+            android:paddingLeft="6dp"
+            android:paddingRight="6dp"
+            android:singleLine="true"
+            android:textSize="18sp" />
 
         <LinearLayout
-            android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/renamefeed_feedname"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
+            android:layout_below="@+id/renamefeed_feedname"
             android:layout_marginLeft="0dp"
-            android:layout_marginRight="0dp">
+            android:layout_marginRight="0dp"
+            android:orientation="horizontal">
 
             <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_height="wrap_content"
-                android:text="Cancel"
                 android:id="@+id/button_rename_cancel"
-                android:layout_weight="1"
+                style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="0dp"
-                android:layout_marginLeft="0dp" />
+                android:layout_height="wrap_content"
+                android:layout_marginStart="0dp"
+                android:layout_weight="1"
+                android:text="@android:string/cancel" />
 
             <Button
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_height="wrap_content"
-                android:text="Rename"
                 android:id="@+id/button_rename_confirm"
-                android:layout_toEndOf="@id/button_rename_cancel"
-                android:layout_weight="1"
+                style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="0dp"
-                android:layout_marginRight="0dp" />
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="0dp"
+                android:layout_weight="1"
+                android:text="@string/feed_rename_button" />
         </LinearLayout>
 
     </RelativeLayout>
@@ -180,7 +176,7 @@
         android:id="@+id/progressView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/ic_menu_item_text"
+        android:layout_below="@+id/tv_menu_text"
         android:layout_marginTop="13dp"
         android:visibility="gone">
         <ProgressBar

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -70,6 +70,11 @@
     <string name="intent_title_share">Share via</string>
 
 
+    <!-- Strings related to NewsReaderListDialogFragment (Rename/Remove Feed) -->
+    <string name="action_feed_remove">Remove Feed</string>
+    <string name="action_feed_rename">Rename Feed</string>
+
+    
     <!-- Strings related to login -->
     <string name="pref_title_username">Username</string>
     <string name="pref_title_password">Password</string>

--- a/News-Android-App/src/main/res/values/strings.xml
+++ b/News-Android-App/src/main/res/values/strings.xml
@@ -73,8 +73,10 @@
     <!-- Strings related to NewsReaderListDialogFragment (Rename/Remove Feed) -->
     <string name="action_feed_remove">Remove Feed</string>
     <string name="action_feed_rename">Rename Feed</string>
+    <string name="feed_remove_button">Remove</string>
+    <string name="feed_rename_button">Rename</string>
+    <string name="confirm_feed_remove">Do you really want to remove this Feed? This cannot be undone!</string>
 
-    
     <!-- Strings related to login -->
     <string name="pref_title_username">Username</string>
     <string name="pref_title_password">Password</string>


### PR DESCRIPTION
See Issue #455
Longpress on a Feed(source) opens up NewsReaderListDialogFragment:

![owncloudnewsapp-renameremove](https://cloud.githubusercontent.com/assets/1008399/12006653/aea144da-abdf-11e5-8e9c-5bdffe754437.png)

Here you can select to **rename** or **remove** the selected feed.
The code first tries to propagate the change (rename/remove) to the server (JSON-Request), 
- upon success, the local db is updated accordingly so that the following sync performs smoothly
- upon failure, no local change is made and an error message is shown.

Tested it for several weeks now without any problems.

Note:
Because the "Feedurl" was not in the local db in previous versions, it may happen, that the Feed's Url is not shown in the DialogFragment's subtitle-line! The Feedurl initially gets synced to the device when a feed has new items, or for all feeds at once, when you do a app data removal and resync. Once every feed got updated, all feedurls are present. 

(On some files leading spaces have been converted to tabs accidentally, so sorry for slightly confusing diff/compare-view.)

I hope you give it a try and consider merging.
Let me know if there is something more to do for this pullrequest!
cheers :) 

![owncloudnewsapp-renameremove02](https://cloud.githubusercontent.com/assets/1008399/12006760/292518a4-abe4-11e5-9560-f3565197bc69.png)
