### PR TITLE
fix theme of all dialogFragments

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
@@ -153,8 +153,8 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
 
         int style = DialogFragment.STYLE_NO_TITLE;
         int theme = ThemeChooser.isDarkTheme(getActivity())
-                ? R.style.Theme_Material_Dialog_Floating
-                : R.style.Theme_Material_Light_Dialog_Floating;
+                ? R.style.FloatingDialog
+                : R.style.FloatingDialogLight;
         setStyle(style, theme);
     }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsReaderListDialogFragment.java
@@ -94,8 +94,8 @@ public class NewsReaderListDialogFragment extends DialogFragment{
 
         int style = DialogFragment.STYLE_NO_TITLE;
         int theme = ThemeChooser.isDarkTheme(getActivity())
-                ? R.style.Theme_Material_Dialog_Floating
-                : R.style.Theme_Material_Light_Dialog_Floating;
+                ? R.style.FloatingDialog
+                : R.style.FloatingDialogLight;
         setStyle(style, theme);
     }
 

--- a/News-Android-App/src/main/res/values/styles.xml
+++ b/News-Android-App/src/main/res/values/styles.xml
@@ -63,11 +63,11 @@
         <item name="android:background">@color/news_detail_background_color_light_theme</item>
     </style>
 
-    <style name="Theme.Material.Dialog.Floating" parent="@android:style/Theme.Material.Dialog" >
+    <style name="FloatingDialog" parent="AppTheme" >
         <item name="android:windowIsFloating">true</item>
         <item name="android:windowCloseOnTouchOutside">true</item>
     </style>
-    <style name="Theme.Material.Light.Dialog.Floating" parent="@android:style/Theme.Material.Light.Dialog" >
+    <style name="FloatingDialogLight" parent="AppThemeLight" >
         <item name="android:windowIsFloating">true</item>
         <item name="android:windowCloseOnTouchOutside">true</item>
     </style>


### PR DESCRIPTION
Removed API21-styles from all DialogFragments. Reverted to AppTheme.
(NewsDetailImageDialogFragment and NewsReaderListDialogFragment)
https://github.com/owncloud/News-Android-App/commit/1f1b06f96ba97e52ae6bc5086e2db78d85c298e8#commitcomment-15337011