### PR TITLE
Optimize NewsDetailImageDialogFragment

### DIFF
--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
@@ -308,16 +308,7 @@ public class NewsDetailFragment extends Fragment {
 
                 Document htmldoc = Jsoup.parse(html);
 
-                // DialogFragment.show() will take care of adding the fragment
-                // in a transaction.  We also want to remove any currently showing
-                // dialog, so make our own transaction and take care of that here.
                 FragmentTransaction ft = getFragmentManager().beginTransaction();
-                Fragment prev = getFragmentManager().findFragmentByTag("menu_fragment_dialog");
-                if (prev != null) {
-                    ft.remove(prev);
-                }
-                ft.addToBackStack(null);
-
 
                 if (type == WebView.HitTestResult.IMAGE_TYPE || type == WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE) {
                     String imageUrl = result.getExtra();

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailFragment.java
@@ -371,38 +371,10 @@ public class NewsDetailFragment extends Fragment {
                 //else if (type == WebView.HitTestResult.EDIT_TEXT_TYPE) { }
             }
         }
-
-
-
-
     }
 
 
-    @Override
-    public boolean onContextItemSelected(MenuItem item) {
-        if( !getUserVisibleHint() ) {
-            return false;
-        }
-        switch (item.getItemId()) {
-            /*
-            case R.id.action_downloadimg:
-                downloadImage(imageUrl);
-                return true;
-            case R.id.action_shareimg:
-                //Intent Share
-                return true;
-            case R.id.action_openimg:
-                openImageInBrowser(imageUrl);
-                return true;
-                */
-            default:
-                return super.onContextItemSelected(item);
-        }
-    }
-
-
-
-
+    
     @SuppressLint("SimpleDateFormat")
 	public static String getHtmlPage(Context context, RssItem rssItem, boolean showHeader)
 	{

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
@@ -120,7 +120,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
                 mMenuItems.put(getString(R.string.action_img_copylink), new MenuAction() {
                     @Override
                     public void execute() {
-                        copyToCipboard(mDialogTitle, mImageUrl.toString());
+                        copyToClipboard(mDialogTitle, mImageUrl.toString());
                     }
                 });
                 break;
@@ -145,7 +145,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
                 mMenuItems.put(getString(R.string.action_link_copy), new MenuAction() {
                     @Override
                     public void execute() {
-                        copyToCipboard(mDialogTitle, mDialogText);
+                        copyToClipboard(mDialogTitle, mDialogText);
                     }
                 });
                 break;
@@ -247,7 +247,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
     }
 
 
-    private void copyToCipboard(String label, String text) {
+    private void copyToClipboard(String label, String text) {
         ClipboardManager clipboard = (ClipboardManager) getActivity().getSystemService(Activity.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(label, text);
         clipboard.setPrimaryClip(clip);

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
@@ -375,11 +375,13 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
                     switch (status) {
                         case DownloadManager.STATUS_SUCCESSFUL:
                             Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_img_saved), Toast.LENGTH_LONG).show();
-                            dismiss();
+                            try { dismiss(); }
+                            catch (Exception e) {}
                             break;
                         case DownloadManager.STATUS_FAILED:
                             Toast.makeText(getActivity().getApplicationContext(), getString(R.string.error_download_failed) + ": " + reason, Toast.LENGTH_LONG).show();
-                            dismiss();
+                            try { dismiss(); }
+                            catch (Exception e) {}
                             break;
                     }
                 }

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
@@ -252,7 +252,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
         ClipData clip = ClipData.newPlainText(label, text);
         clipboard.setPrimaryClip(clip);
         Toast.makeText(getActivity(), getString(R.string.toast_copied_to_clipboard), Toast.LENGTH_SHORT).show();
-        getDialog().dismiss();
+        dismiss();
     }
 
     private void shareImage() {
@@ -261,7 +261,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
         sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, mDialogText);
         sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, mImageUrl.toString());
         startActivity(Intent.createChooser(sharingIntent, getString(R.string.intent_title_share)));
-        getDialog().dismiss();
+        dismiss();
     }
 
     private void shareLink() {
@@ -270,7 +270,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
         sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, mDialogTitle);
         sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, mDialogText);
         startActivity(Intent.createChooser(sharingIntent, getString(R.string.intent_title_share)));
-        getDialog().dismiss();
+        dismiss();
     }
 
 
@@ -278,7 +278,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
         Intent i = new Intent(Intent.ACTION_VIEW);
         i.setData(Uri.parse(url.toString()));
         startActivity(i);
-        getDialog().dismiss();
+        dismiss();
     }
 
     private void downloadImage(URL url) {
@@ -297,7 +297,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
             getDialog().hide();
         } else {
             Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_img_notwriteable), Toast.LENGTH_LONG).show();
-            getDialog().dismiss();
+            dismiss();
         }
     }
 
@@ -356,7 +356,6 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
     }
 
     private void registerImageDownloadReceiver() {
-        IntentFilter intentFilter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
         if(downloadCompleteReceiver != null) return;
 
         downloadCompleteReceiver = new BroadcastReceiver() {
@@ -376,16 +375,17 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
                     switch (status) {
                         case DownloadManager.STATUS_SUCCESSFUL:
                             Toast.makeText(getActivity().getApplicationContext(), getString(R.string.toast_img_saved), Toast.LENGTH_LONG).show();
-                            getDialog().dismiss();
+                            dismiss();
                             break;
                         case DownloadManager.STATUS_FAILED:
-                            Toast.makeText(getActivity().getApplicationContext(), getString(R.string.error_download_failed) +": " +reason, Toast.LENGTH_LONG).show();
-                            getDialog().dismiss();
+                            Toast.makeText(getActivity().getApplicationContext(), getString(R.string.error_download_failed) + ": " + reason, Toast.LENGTH_LONG).show();
+                            dismiss();
                             break;
                     }
                 }
             }
         };
+        IntentFilter intentFilter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
         getActivity().registerReceiver(downloadCompleteReceiver, intentFilter);
     }
 

--- a/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
+++ b/News-Android-App/src/main/java/de/luhmer/owncloudnewsreader/NewsDetailImageDialogFragment.java
@@ -186,8 +186,6 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
 
-        registerImageDownloadReceiver();
-
         View v = inflater.inflate(R.layout.fragment_dialog_image, container, false);
 
         TextView tvTitle = (TextView) v.findViewById(R.id.ic_menu_title);
@@ -199,6 +197,7 @@ public class NewsDetailImageDialogFragment extends DialogFragment {
         imgTitle.setImageResource(mDialogIcon);
 
         if(mDialogType == TYPE.IMAGE) {
+            registerImageDownloadReceiver();
             if(mDialogText.equals(mDialogTitle) || mDialogText.equals("")) {
                 tvText.setVisibility(View.GONE);
             }


### PR DESCRIPTION
- Fixes a small bug with the NewsDetailImageDialogFragment:
  - —> Longpress > "Download Image" on Image1
  - —> Longpress on Image2 before Image1 finished downloading
  - —> Dismiss dialog of Image2 (through clicking outside the dialog)
  - —> **BUG:** The dialog of Image1 appears again
- Fixed Typo (Cipboard > Clipboard)
- Removed unused method in NewsDetailFragment
- other small optimizations
