### PR TITLE
accept more rss urls

### DIFF
--- a/News-Android-App/src/main/AndroidManifest.xml
+++ b/News-Android-App/src/main/AndroidManifest.xml
@@ -78,6 +78,8 @@
                 <data android:pathPattern=".*\\atom.xml" />
                 <data android:pathPattern=".*\\rss.xml" />
                 <data android:pathPattern=".*\\.rss" />
+                <data android:pathPattern=".*/feed" />
+                <data android:pathPattern=".*feed/*" />
 
                 <data android:scheme="http" android:host="*"
                     android:pathPattern=".*\\.opml" />


### PR DESCRIPTION
Some websites like youtube offer rss but don't name it *.rss or *.atom.xml
So this small change on the AndroidManifest will make thous sites also support such rss links.